### PR TITLE
corrected astrobot.database.new_bot_action setting a CID to a URI

### DIFF
--- a/src/astrobot/database.py
+++ b/src/astrobot/database.py
@@ -61,7 +61,7 @@ def new_bot_action(
     if latest_uri is None:
         latest_uri = command.notification.parent_ref.uri
     if latest_cid is None:
-        latest_cid = command.notification.parent_ref.uri
+        latest_cid = command.notification.parent_ref.cid
 
     # db.connect(reuse_if_open=True)
     setup_connection(get_database())


### PR DESCRIPTION
In `astrobot.database`, in the function `new_bot_action`, the lines

```
if latest_uri is None:
    latest_uri = command.notification.parent_ref.uri
if latest_cid is None:
    latest_cid = command.notification.parent_ref.uri

```

should be

```
if latest_uri is None:
    latest_uri = command.notification.parent_ref.uri
if latest_cid is None:
    latest_cid = command.notification.parent_ref.cid
```

This change has been made in this branch.