### PR TITLE
Feature: dev_db from SQLite source

### DIFF
--- a/src/astrofeed_lib/dev_database.py
+++ b/src/astrofeed_lib/dev_database.py
@@ -6,7 +6,124 @@ import warnings
 
 from datetime import datetime
 
-from .database import Account, Post, BotActions, ModActions, SubscriptionState
+from .database import Account, Post, BotActions, ModActions, SubscriptionState, setup_connection, teardown_connection
+
+def build_dev_db(
+        source_database_name : str = "dbdump.db",
+        destination_database_name : str = "dev_db.db",
+        overwrite_existing : bool = False,
+        take_num : int = 50000, 
+        take_frac : float = 0.0, 
+        sampling_strategy : str = "last"
+    ):
+    """Reduce volume of stored data, by sampling given amount according to given strategy.
+
+    For the moment, this is built assuming that we have a 'complete' database (all models have associated 
+    dataframes of data), and the method itself demands that we at least have a Post table to initially 
+    sample from.
+
+    in:
+        source_database_name: string representing path to source database
+        destination_database_name: string representing path to developed database to create
+        take_num: number of entries to take from Post table (mutually exclusive with take_frac)
+        take_frac: fraction of entries to take from Post table (mutually exclusive with take_num)
+        sampling_strategy: string indicating sampling strategy to use            
+    """
+    # 
+    to_write = dict({
+        Post : None,
+        Account : None,
+        BotActions : None,
+        ModActions : None,
+        SubscriptionState : None
+        }
+    )
+
+    # setup database connections
+    db_conn_source = peewee.SqliteDatabase(source_database_name)
+
+    if(os.path.isfile(destination_database_name)):
+        if overwrite_existing:
+            warnings.warn(f"Found pre-existing file {destination_database_name}, and overwrite_existing=True: removing and replacing file.")
+            os.remove(destination_database_name)
+        else:
+            raise FileExistsError(f"Found pre-existing file {destination_database_name}, and overwrite_existing=False:\n \
+                                  please select another name for new database; move, remove, or rename existing \n\
+                                  dev database; or re-run with argument 'overwrite_existing=True' to overwrite.")
+    db_conn_destination = peewee.SqliteDatabase(destination_database_name)
+    for model in to_write.keys():
+        with model.bind_ctx(db_conn_destination):
+            db_conn_destination.create_tables([model])
+
+    # only two sampling strategies implemented, default to last n posts
+    supported_sampling_strategies = ["first", "last"]
+    if(sampling_strategy not in supported_sampling_strategies):
+        warnings.warn(f"dev_database/DB/truncate: \n\
+                        Sampling strategy must be one of {supported_sampling_strategies}; setting sampling_strategy='last'.")
+        sampling_strategy = "last"
+
+    # now we build a dictionary of data to write (in the form of lists of dicts)
+    with Post.bind_ctx(db_conn_source):
+        # make sure our take_num/take_frac make sense
+        total_posts = Post.select().count()
+
+        if(((take_num!=0) == (take_frac!=0)) or (take_num < 0 or take_frac < 0)):
+            raise ValueError(f"dev_database/DB/truncate: \n\
+                                must specify a positive (nonzero) value for only one of take_num or take_frac.")
+        elif(take_num > 0):
+            if(take_num > total_posts):
+                warnings.warn(f"dev_database/DB/truncate: \n\
+                        {take_num} Post entries requested, but only {total_posts} available. Setting take_num={total_posts}")
+                take_num = total_posts
+        else:
+            if(take_frac > 1):
+                warnings.warn("dev_database/DB/truncate: take_frac > 1.0, setting take_frac=1.0")
+                take_frac = 1.0
+            take_num = round(take_frac*total_posts)
+
+        # initial sampling of Post
+        match sampling_strategy:
+            case "last":
+                sampled_posts = list(Post.select().order_by(Post.indexed_at.desc()).limit(take_num).dicts())
+            case "first":
+                sampled_posts = list(Post.select().order_by(Post.indexed_at.asc()).limit(take_num).dicts())
+        
+        # set posts to write
+        to_write[Post] = sampled_posts
+
+
+    with ModActions.bind_ctx(db_conn_source):
+        # next, we get the unique DIDs making those posts, as well as the DIDs of mods who interacted with those users
+        user_dids = set([entry["author"] for entry in sampled_posts])
+        mod_dids  = set(ModActions.select(ModActions.did_mod).where(ModActions.did_user << user_dids))
+
+        # together, these DIDs tell us who we're interested in from each non-user table, and we can sample from ModActions
+        dids = user_dids.union(mod_dids)
+        sampled_modactions = list(ModActions.select().where(ModActions.did_user << dids).dicts())
+
+        # set to write
+        to_write[ModActions] = sampled_modactions
+
+    # BotActions and Account don't contribute additional sampling contraints, and both have a DID field, so we can 
+    # sample from them together
+    for model in [Account, BotActions]:
+        with model.bind_ctx(db_conn_source):
+            to_write[model] = list(model.select().where(model.did << dids).dicts())
+
+    # SubscriptionState seems to always be a single entry, so we can just move that over as is
+    with SubscriptionState.bind_ctx(db_conn_source):
+        to_write[SubscriptionState] = list(SubscriptionState.select().dicts())
+
+    # now, we write everything!
+    for model, data in to_write.items():
+        with model.bind_ctx(db_conn_destination):
+            with db_conn_destination.atomic():
+                for batch in peewee.chunked(data, 100):
+                    model.insert_many(batch).execute()
+
+##
+## DEPRECATED
+##
 
 ##
 ## main class that contains logic/methods for interacting with developer database, and data source to truncate from
@@ -267,7 +384,7 @@ class DB():
 ## main function to be used outside of this module
 ##
 
-def build_dev_db(data_source: str, 
+def build_dev_db_from_parquet(data_source: str, 
                  source_format: str = "parquet", 
                  database_engine: str = "sqlite", 
                  truncation_num: int = 50000,
@@ -286,6 +403,10 @@ def build_dev_db(data_source: str,
         truncation_strat: strategy to use for truncation
         overwrite_existing: boolean indicating whether to overwrite a pre-existing database
     """
+    warnings.warn(f"You are using a deprecated method for building a developer database, which has not \n\
+                  been tested against the updated database schema. Unexpected results may occur, procede \n\
+                  at your own risk.")
+
     # initialize database
     if(os.path.isfile(database_name)):
         if overwrite_existing:

--- a/src/astrofeed_lib/dev_database.py
+++ b/src/astrofeed_lib/dev_database.py
@@ -30,7 +30,7 @@ class DB():
     """
 
     # what is currently supported
-    supported_source_formats      = ["parquet"]
+    supported_source_formats      = ["parquet", "sqlite"]
     supported_sampling_strategies = ["first", "last", "random"]
 
     def __init__(self, db_conn: peewee.Database):
@@ -62,6 +62,12 @@ class DB():
         """
 
         format = format.lower()
+
+        if(format not in self.supported_source_formats):
+            raise NotImplementedError(f"dev_database/DB/populate_from_source: \
+                                        {format} not a supported format, please use one of the following: \
+                                        {self.supported_source_formats}")
+
         match format:
             case "parquet":
                 # assume we are given a directory of tablename.parquet files that match our database structure
@@ -76,6 +82,37 @@ class DB():
                                                       Source directory must contain files for each of these tables: ({self.models.keys()})")
                 else:
                     raise NotADirectoryError(f"dev_database/DB/populate_from_source: No such directory '{source}': expecting a directory.")
+
+            case "sqlite":
+                # assume we're given a pre-existing database that matches the schema defined in our model classes
+
+                # first, make sure we're given a pre-existing database file
+                if not os.path.isfile(source):
+                    raise FileNotFoundError(f"dev_database/DB/populate_from_source: \
+                                            Unable to find {source} file; must be a pre-existing SQLite database file.")
+                try:
+                    source_db_conn = peewee.SqliteDatabase(source)
+                    source_tables = source_db_conn.get_tables()
+                except peewee.DatabaseError as err:
+                    print(f"dev_database/DB/populate_from_source: \
+                          could not parse {source} as an SqLite database file.")
+                    raise err
+
+                # now check to make sure that the database is complete
+                if set(source_tables) != set([table_name.lower() for table_name in self.models.keys()]):
+                    raise RuntimeError(f"dev_database/DB/populate_from_source: \n\
+                                            Database at {source} does not contain all necessary tables to populate a \n\
+                                            new database (has {source_tables} tables, must have {self.models.keys()} tables).")
+
+                # now we can try to transfer database data to our internal representation
+                for model_name, model in self.models.items():
+                    try:
+                        with model.bind_ctx(source_db_conn):
+                            self.data[model_name] = pandas.DataFrame(model.select().dicts())
+                    except peewee.DatabaseError as err:
+                        print(f"dev_database/DB/populate_from_source: \
+                            {model} table from {source} database does not match defined schema.")
+                        raise err
 
             case _:
                 raise NotImplementedError(f"dev_database/DB/populate_from_source: \
@@ -157,26 +194,33 @@ class DB():
                 # different replacement needs for different columns
                 match column:
                     case "indexed_at":
-                        replacement_label = "indexed_at"
+                        if(type(df["indexed_at"].iloc[0]) is datetime):
+                            # no need to clean
+                            continue
+                        else:
+                            replacement_label = "indexed_at"
 
-                        # make copy of column in python date-time format
-                        with warnings.catch_warnings(): # suppresses deprecation warnings from to_pydatetime
-                            warnings.simplefilter("ignore")
-                            replacement_data = df["indexed_at"].dt.to_pydatetime()
-                        replacement_data = pandas.Series(replacement_data, dtype=object)
+                            # make copy of column in python date-time format
+                            with warnings.catch_warnings(): # suppresses deprecation warnings from to_pydatetime
+                                warnings.simplefilter("ignore")
+                                replacement_data = df["indexed_at"].dt.to_pydatetime()
+                            replacement_data = pandas.Series(replacement_data, dtype=object)
 
                     case "checked_at":
-                        replacement_label = "checked_at"
+                        if(type(df["checked_at"].iloc[0]) is datetime):
+                            # no need to clean
+                            continue
+                        else:
+                            # replace possible all-zeroes entries that we can't convert first
+                            date_strings = numpy.array(df["checked_at"])
+                            replacement_label = "checked_at"
+                            replacement_data = []
+                            for i in range(len(date_strings)):
+                                if date_strings[i] == "0000-00-00 00:00:00":
+                                    date_strings[i] = "0001-01-01 00:00:01"
+                                replacement_data.append(datetime.strptime(date_strings[i], "%Y-%m-%d %H:%M:%S"))
 
-                        # replace possible all-zeroes entries that we can't convert first
-                        date_strings = numpy.array(df["checked_at"])
-                        replacement_data = []
-                        for i in range(len(date_strings)):
-                            if date_strings[i] == "0000-00-00 00:00:00":
-                                date_strings[i] = "0001-01-01 00:00:01"
-                            replacement_data.append(datetime.strptime(date_strings[i], "%Y-%m-%d %H:%M:%S"))
-
-                        replacement_data = pandas.Series(replacement_data)
+                            replacement_data = pandas.Series(replacement_data)
 
                     case _: # no cleaning needed
                         continue
@@ -224,17 +268,18 @@ class DB():
 ##
 
 def build_dev_db(data_source: str, 
-                 data_format: str = "parquet", 
+                 source_format: str = "parquet", 
                  database_engine: str = "sqlite", 
                  truncation_num: int = 50000,
                  truncation_frac: float = 0.0,
                  truncation_strat: str = "last",
+                 database_name : str = "dev_db.db",
                  overwrite_existing: bool = False):
     """Build a smaller, developer-friendly database from source data.
 
     in:
         data_souce: string locating un-truncated data to read in
-        data_format: string indicating format of data in source
+        source_format: string indicating format of data in source
         database_engine: string indicating which engine to use for the developer database
         truncation_num: number of entries in the Post table to truncate to
         truncation_frac: fraction of entries in the Post table to truncate to
@@ -242,26 +287,26 @@ def build_dev_db(data_source: str,
         overwrite_existing: boolean indicating whether to overwrite a pre-existing database
     """
     # initialize database
-    if(os.path.isfile("dev_db.db")):
+    if(os.path.isfile(database_name)):
         if overwrite_existing:
-            warnings.warn("Found pre-existing dev_db.db, and overwrite_existing=True: removing file.")
-            os.remove("dev_db.db")
+            warnings.warn(f"Found pre-existing file {database_name}, and overwrite_existing=True: removing file.")
+            os.remove(database_name)
         else:
-            raise FileExistsError("Found pre-existing dev_db.db, and overwrite_existing=False:\n \
-                                   please move, remove, or rename existing dev database, or re-run with \
-                                   argument 'overwrite_existing=True'")
+            raise FileExistsError(f"Found pre-existing file {database_name}, and overwrite_existing=False:\n \
+                                  please select another name for new database; move, remove, or rename existing \
+                                  dev database; or re-run with argument 'overwrite_existing=True' to overwrite.")
 
     database_engine = database_engine.lower()
     match database_engine:
         case "sqlite":
-            db_conn = peewee.SqliteDatabase("dev_db.db")
+            db_conn = peewee.SqliteDatabase(database_name)
         case _:
             raise NotImplementedError(f"dev_database/build_dev_db: {database_engine} not supported, sorry!")
 
     database = DB(db_conn)
 
     # populate and process our data
-    database.populate_from_source(source=data_source, format=data_format)
+    database.populate_from_source(source=data_source, format=source_format)
     database.truncate(take_num=truncation_num, take_frac=truncation_frac, sampling=truncation_strat)
     database.clean()
 

--- a/src/astrofeed_lib/dev_database.py
+++ b/src/astrofeed_lib/dev_database.py
@@ -6,7 +6,7 @@ import warnings
 
 from datetime import datetime
 
-from .database import Account, Post, BotActions, ModActions, SubscriptionState, setup_connection, teardown_connection
+from .database import Account, Post, BotActions, ModActions, SubscriptionState
 
 def build_dev_db(
         source_database_name : str = "dbdump.db",


### PR DESCRIPTION
Added the ability to create a developer database from a pre-existing SQLite database, without needing to go through Pandas middle stage.

Given the regular dumping of the production database into an SQLite file, this should enable the creation of developer databases without having to deal with the additional complexities of storing the data in Pandas dataframes. The old sampling logic --- in which we first sample a certain number of Post entries, then grab all entries from other tables in which the DIDs of those entries authors (and DIDs of moderators who have moderated them) appear --- has been replicated using Peewee queries on the source database.

Deprecation warnings have been added to the old method (from parquet files, using Pandas to store and sample), since it has not been tested with the current schema.