### PR TITLE
Hotfix astrobot test bugs

### DIFF
--- a/src/astrobot/database.py
+++ b/src/astrobot/database.py
@@ -198,11 +198,11 @@ def update_checked_at_time_of_bot_actions(ids: list):
 def hide_post_by_uri(uri: str, did: str) -> tuple[bool, str]:
     """Hides a post from the feeds. Returns a string saying if there was (or wasn't) success."""
     # db.connect(reuse_if_open=True)
-    setup_connection(get_database())
     account_entries = fetch_account_entry_for_did(did)
     post_entires = fetch_post_entry_for_uri(uri)
 
     # Perform checks on account & post
+    setup_connection(get_database())
     if len(account_entries) == 0:
         return False, "Unable to hide post: post author is not signed up to the feeds."
     if len(post_entires) == 0:
@@ -219,6 +219,7 @@ def hide_post_by_uri(uri: str, did: str) -> tuple[bool, str]:
     # Hide the post
     post, account = post_entires[0], account_entries[0]
     if post.hidden:
+        teardown_connection(get_database())
         return False, "Unable to hide post: post already hidden."
 
     post.hidden = True

--- a/src/astrofeed_lib/database.py
+++ b/src/astrofeed_lib/database.py
@@ -139,7 +139,7 @@ class DBConnection(object):
     def __enter__(self):
         global proxy
         if proxy is not None and proxy.is_closed():
-            proxy.connect()
+            setup_connection(proxy)
         return proxy
 
     def __exit__(self, type, value, traceback):


### PR DESCRIPTION
During the course of creating tests for the astrobot hide command, I discovered several bugs which caused the tests to fail. I have taken steps to rectify these bugs, and with the changes I made in place (as detailed below), the tests all pass.

In `astrobot.database`,  the `hide_post_by_uri` function opens a database connection before calling `fetch_account_entry_for_did` and `fetch_post_entry_for_uri`, which each open and close the same database connection internally; this results both in an error about the connection already being open, and in an error about the database connection not being open later in the function (after it has been closed at the end of `fetch_post_entry_for_uri`, and not reopened before saving the modified post and account entries). To fix this, I moved the database opening to after the calls to `fetch_account_entry_for_did` and `fetch_post_entry_for_uri`, so that there is not a duplicated entry attempt, and that instead the database connection is opened after being closed in `fetch_post_entry_for_uri`, and before the attempted post and save entry updates.

In `astrobot.database`,  the `hide_post_by_uri` function closes its database connection before returning in the case of a successful hide action, but when the post to hide is already hidden, we enter a code block (from `if post.hidden`) that returns from the function without closing the connection; this can result in errors about the database connection already being open when future functions try to open it. To fix this, I added a call to `teardown_connection(get_database())` to this code block, before the return.

In `astrofeed_lib.database`, the DBConnection context manager class uses the `teardown_connection` method to close a database connection in `__exit__`, but does not use it's equivalent `setup_connection` in the `__enter__` function to open the database connection; this results in logged messages that indicate the closing of databases without corresponding messages about them opening, as well as some logic that is applied to closing the database connections (making sure the connection exists and isn't already closed) not being apply to the opening step. To fix this, I changed the call to `proxy.connect()` to a call to `setup_connection(proxy)`.