### PR TITLE
Feature: ban command

### DIFF
--- a/src/astrobot/commands/moderation/ban.py
+++ b/src/astrobot/commands/moderation/ban.py
@@ -27,22 +27,15 @@ class ModeratorBanCommand(Command):
     def execute_good_permissions(self, client: Client):
                 # Default failure case
         explanation = (
-            "Unable to execute ban; this command must reply to or specify the user to ban."
+            "Unable to execute ban; this command must specify the handle of the user to ban."
         )
 
         # if command post is a reply, ban replied-to user
-        if self.notification.notification.record.reply is not None:
-            uri_to_ban = self.notification.notification.record.reply.parent.uri
-            did_to_ban = uri_to_ban.replace("at://", "").split("/")[0]
-            mod_did = self.notification.author.did
-            ban_reason = " ".join(self.notification.words[1:]) # perhaps this should be different? multi-step command to get reason?
-            explanation = ban_user(did=did_to_ban, did_mod=mod_did, reason=ban_reason)
-
-        # otherwise, check for handle to ban after command word
-        # note: to check handle validity, we should check whether the handle actually resolves, rather than whether we have an entry 
-        # with that handle already; in case whoever we are trying to ban has changed their handle since they registered to post
-        elif self.notification.words[1][0] == "@":
-            handle_to_ban = self.notification.words[1][1:]
+        if len(self.notification.words) > 1:
+            handle_to_ban = self.notification.words[1]
+            # note: to check handle validity, we should check whether the handle actually resolves and use the DID from there, rather 
+            # than checking whether we have an entry with that handle already; in case whoever we are trying to ban has changed their 
+            # handle since they registered to post
             if did_to_ban := IdResolver(timeout=30).handle.resolve(handle_to_ban):
                 mod_did = self.notification.author.did
                 ban_reason = " ".join(self.notification.words[2:]) # perhaps this should be different? multi-step command to get reason?

--- a/src/astrobot/commands/moderation/ban.py
+++ b/src/astrobot/commands/moderation/ban.py
@@ -25,12 +25,12 @@ class ModeratorBanCommand(Command):
             return ModeratorBanCommand(notification)
 
     def execute_good_permissions(self, client: Client):
-                # Default failure case
+        # Default failure case
         explanation = (
             "Unable to execute ban; this command must specify the handle of the user to ban."
         )
 
-        # if command post is a reply, ban replied-to user
+        # make sure there is a specified handle to ban
         if len(self.notification.words) > 1:
             handle_to_ban = self.notification.words[1]
             # note: to check handle validity, we should check whether the handle actually resolves and use the DID from there, rather 
@@ -38,14 +38,14 @@ class ModeratorBanCommand(Command):
             # handle since they registered to post
             if did_to_ban := IdResolver(timeout=30).handle.resolve(handle_to_ban):
                 mod_did = self.notification.author.did
-                ban_reason = " ".join(self.notification.words[2:]) # perhaps this should be different? multi-step command to get reason?
+                ban_reason = " ".join(self.notification.words[2:])
                 explanation = ban_user(did=did_to_ban, did_mod=mod_did, reason=ban_reason)
             else:
                 explanation = (
                     f"Unable to execute ban; not able to resolve given user handle \"{handle_to_ban}\""
                 )
 
-        # & inform the user
+        # inform the user of the outcome
         send_post(
             client,
             explanation,

--- a/src/astrobot/commands/moderation/ban.py
+++ b/src/astrobot/commands/moderation/ban.py
@@ -26,24 +26,22 @@ class ModeratorBanCommand(Command):
 
     def execute_good_permissions(self, client: Client):
         # Default failure case
-        explanation = (
-            "Unable to execute ban; this command must specify the handle of the user to ban."
-        )
+        explanation = "Unable to execute ban; this command must specify the handle of the user to ban."
 
         # make sure there is a specified handle to ban
         if len(self.notification.words) > 1:
             handle_to_ban = self.notification.words[1]
-            # note: to check handle validity, we should check whether the handle actually resolves and use the DID from there, rather 
-            # than checking whether we have an entry with that handle already; in case whoever we are trying to ban has changed their 
+            # note: to check handle validity, we should check whether the handle actually resolves and use the DID from there, rather
+            # than checking whether we have an entry with that handle already; in case whoever we are trying to ban has changed their
             # handle since they registered to post
             if did_to_ban := IdResolver(timeout=30).handle.resolve(handle_to_ban):
                 mod_did = self.notification.author.did
                 ban_reason = " ".join(self.notification.words[2:])
-                explanation = ban_user(did=did_to_ban, did_mod=mod_did, reason=ban_reason)
-            else:
-                explanation = (
-                    f"Unable to execute ban; not able to resolve given user handle \"{handle_to_ban}\""
+                explanation = ban_user(
+                    did=did_to_ban, did_mod=mod_did, reason=ban_reason
                 )
+            else:
+                explanation = f'Unable to execute ban; not able to resolve given user handle "{handle_to_ban}"'
 
         # inform the user of the outcome
         send_post(

--- a/src/astrobot/commands/moderation/ban.py
+++ b/src/astrobot/commands/moderation/ban.py
@@ -14,8 +14,13 @@ class ModeratorBanCommand(Command):
     command = "ban"
     level = 3
 
-    def __init__(self, notification: MentionNotification):
+    def __init__(
+        self,
+        notification: MentionNotification,
+        id_resolver: IdResolver = IdResolver(timeout=30),
+    ):
         self.notification = notification
+        self.id_resolver = id_resolver
 
     @staticmethod
     def is_instance_of(
@@ -34,7 +39,7 @@ class ModeratorBanCommand(Command):
             # note: to check handle validity, we should check whether the handle actually resolves and use the DID from there, rather
             # than checking whether we have an entry with that handle already; in case whoever we are trying to ban has changed their
             # handle since they registered to post
-            if did_to_ban := IdResolver(timeout=30).handle.resolve(handle_to_ban):
+            if did_to_ban := self.id_resolver.handle.resolve(handle_to_ban):
                 mod_did = self.notification.author.did
                 ban_reason = " ".join(self.notification.words[2:])
                 explanation = ban_user(

--- a/src/astrobot/commands/moderation/ban.py
+++ b/src/astrobot/commands/moderation/ban.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from atproto import Client
+from atproto import Client, IdResolver
 from astrobot.commands._base import Command
 from astrobot.notifications import MentionNotification
+from astrobot.database import new_bot_action
+from astrobot.moderation import ban_user
+from astrobot.post import send_post
 
 
 class ModeratorBanCommand(Command):
@@ -12,7 +15,6 @@ class ModeratorBanCommand(Command):
     level = 3
 
     def __init__(self, notification: MentionNotification):
-        raise NotImplementedError()
         self.notification = notification
 
     @staticmethod
@@ -23,4 +25,38 @@ class ModeratorBanCommand(Command):
             return ModeratorBanCommand(notification)
 
     def execute_good_permissions(self, client: Client):
-        pass  # Todo
+                # Default failure case
+        explanation = (
+            "Unable to execute ban; this command must reply to or specify the user to ban."
+        )
+
+        # if command post is a reply, ban replied-to user
+        if hasattr(self.notification.notification.record, "reply"):
+            uri_to_ban = self.notification.notification.record.reply.parent.uri
+            did_to_ban = uri_to_ban.replace("at://", "").split("/")[0]
+            mod_did = self.notification.author.did
+            ban_reason = " ".join(self.notification.words[1:]) # perhaps this should be different? multi-step command to get reason?
+            explanation = ban_user(did=did_to_ban, did_mod=mod_did, reason=ban_reason)
+
+        # otherwise, check for handle to ban after command word
+        # note: to check handle validity, we should check whether the handle actually resolves, rather than whether we have an entry 
+        # with that handle already; in case whoever we are trying to ban has changed their handle since they registered to post
+        elif self.notification.words[1][0] == "@":
+            handle_to_ban = self.notification.words[1][1:]
+            if did_to_ban := IdResolver(timeout=30).handle.resolve(handle_to_ban):
+                mod_did = self.notification.author.did
+                ban_reason = " ".join(self.notification.words[2:]) # perhaps this should be different? multi-step command to get reason?
+                explanation = ban_user(did=did_to_ban, did_mod=mod_did, reason=ban_reason)
+            else:
+                explanation = (
+                    f"Unable to execute ban; not able to resolve given user handle \"{handle_to_ban}\""
+                )
+
+        # & inform the user
+        send_post(
+            client,
+            explanation,
+            root_post=self.notification.root_ref,
+            parent_post=self.notification.parent_ref,
+        )
+        new_bot_action(self)

--- a/src/astrobot/commands/moderation/ban.py
+++ b/src/astrobot/commands/moderation/ban.py
@@ -31,7 +31,7 @@ class ModeratorBanCommand(Command):
         )
 
         # if command post is a reply, ban replied-to user
-        if hasattr(self.notification.notification.record, "reply"):
+        if self.notification.notification.record.reply is not None:
             uri_to_ban = self.notification.notification.record.reply.parent.uri
             did_to_ban = uri_to_ban.replace("at://", "").split("/")[0]
             mod_did = self.notification.author.did

--- a/src/astrobot/config.py
+++ b/src/astrobot/config.py
@@ -4,7 +4,7 @@ import os
 from .commands import CommandRegistry
 from .commands.joke import JokeCommand
 from .commands.signup import SignupCommand
-from .commands.moderation import ModeratorHideCommand
+from .commands.moderation import ModeratorHideCommand, ModeratorBanCommand
 
 
 def _get_handle(handle_env_var: str):
@@ -39,4 +39,4 @@ STALE_COMMAND_CHECK_INTERVAL = (
 
 # Setup command registry
 COMMAND_REGISTRY = CommandRegistry()
-COMMAND_REGISTRY.register_commands([JokeCommand, SignupCommand, ModeratorHideCommand])
+COMMAND_REGISTRY.register_commands([JokeCommand, SignupCommand, ModeratorHideCommand, ModeratorBanCommand])

--- a/src/astrobot/database.py
+++ b/src/astrobot/database.py
@@ -251,8 +251,9 @@ def ban_user_by_did(did: str) -> tuple[bool, str]:
         if not account.is_banned:
             account.is_banned = True
             any_banned = True
-            if account.banned_count > max_ban_count:
-                max_ban_count = account.banned_count
+        if account.banned_count > max_ban_count:
+            max_ban_count = account.banned_count
+
     if any_banned:
         ban_count = max_ban_count+1
         for account in account_entries:

--- a/src/astrobot/database.py
+++ b/src/astrobot/database.py
@@ -231,6 +231,7 @@ def hide_post_by_uri(uri: str, did: str) -> tuple[bool, str]:
     teardown_connection(get_database())
     return True, "Post hidden from feeds successfully."
 
+
 def ban_user_by_did(did: str) -> tuple[bool, str]:
     """Bans a user from the feeds. Returns a string saying if there was (or wasn't) success."""
     account_entries = fetch_account_entry_for_did(did)
@@ -255,7 +256,7 @@ def ban_user_by_did(did: str) -> tuple[bool, str]:
             max_ban_count = account.banned_count
 
     if any_banned:
-        ban_count = max_ban_count+1
+        ban_count = max_ban_count + 1
         for account in account_entries:
             account.banned_count = ban_count
     else:

--- a/src/astrobot/moderation.py
+++ b/src/astrobot/moderation.py
@@ -1,7 +1,12 @@
 """Moderation-related actions."""
 
 from astrofeed_lib.accounts import CachedModeratorList
-from astrobot.database import new_mod_action, new_signup, hide_post_by_uri, ban_user_by_did
+from astrobot.database import (
+    new_mod_action,
+    new_signup,
+    hide_post_by_uri,
+    ban_user_by_did,
+)
 from astrofeed_lib import logger
 
 

--- a/src/astrobot/moderation.py
+++ b/src/astrobot/moderation.py
@@ -1,7 +1,7 @@
 """Moderation-related actions."""
 
 from astrofeed_lib.accounts import CachedModeratorList
-from astrobot.database import new_mod_action, new_signup, hide_post_by_uri
+from astrobot.database import new_mod_action, new_signup, hide_post_by_uri, ban_user_by_did
 from astrofeed_lib import logger
 
 
@@ -11,11 +11,17 @@ MODERATORS = CachedModeratorList(query_interval=60)
 
 def ban_user(did: str, did_mod: str, reason: str):
     """Bans a user from the Astronomy feeds."""
-    logger.info(
-        f"Banning account with DID {did} from the feeds. Mod: {did_mod}. Reason: {reason}."
-    )
-    # todo
-    raise NotImplementedError("ban_user not implemented")
+    success, explanation = ban_user_by_did(did)
+
+    if success:
+        logger.info(
+            f"Banning account with DID {did} from the feeds. Mod: {did_mod}. Reason: {reason}."
+        )
+        new_mod_action(did_mod, did, "ban")
+    else:
+        logger.info(f"Failed to ban accound with DID {did}. Mod: {did_mod}")
+
+    return explanation
 
 
 def mute_user(did: str, did_mod: str, reason: str, days: int):

--- a/tests/astrobot/conftest.py
+++ b/tests/astrobot/conftest.py
@@ -1,0 +1,54 @@
+import pytest
+from atproto import IdResolver
+
+import astrobot.commands.moderation.ban
+
+class MockIdResolver(IdResolver):
+    '''atproto IdResolver replacement that uses mock handle resolver to avoid network checks for handle resolution'''
+    # class variable to store handle -> DID mappings
+    handle_to_did = dict()
+
+    def __init__(self, plc_url = None, timeout = None, cache = None, backup_nameservers = None):
+        super().__init__(plc_url, timeout, cache, backup_nameservers)
+
+        # replace our handle resolver's resolve method with one that uses our internal mappings
+        self.handle.resolve = self.mock_resolve
+
+    def add_mapping(self, handle: str, did: str):
+        '''Adds a new handle -> DID entry into the local dictionary'''
+        handle = handle.lower() # everything is done in lowercased strings for Bsky
+
+        # if handle isn't already present or the DID is different, make the change
+        if handle not in self.handle_to_did.keys() or self.handle_to_did[handle] != did:
+            self.handle_to_did.update({handle:did})
+
+    def remove_mapping_by_handle(self, handle: str):
+        '''Removes an existing handle -> DID entry from the local dictionary'''
+        handle = handle.lower()
+        if handle in self.handle_to_did.keys():
+            del self.handle_to_did[handle]
+            
+
+    def mock_resolve(self, handle):
+        '''Behaves like HandleResolver.resolve, except uses internal mappings rather than network lookup
+        
+        Checks for presence of requested handle in dictionary keys first, and returns None if not present; 
+        to avoid a KeyError and simply return None in the result of no match, to replicate behavior of 
+        mocked method.
+        '''
+        if handle in self.handle_to_did.keys():
+            return self.handle_to_did[handle]
+        else:
+            return None
+
+@pytest.fixture(scope="function")
+def mock_idresolver():
+    '''replace each test's ban command's IdResolver with the mock class, and yield an instance to the test'''
+    store_IdResolver = astrobot.commands.moderation.ban.IdResolver
+    astrobot.commands.moderation.ban.IdResolver = MockIdResolver
+
+    # send an instance of the mock class to the test so that it can easily add mappings as it needs
+    yield MockIdResolver(timeout=30)
+
+    # cleanup; put original IdResolver back
+    astrobot.commands.moderation.ban.IdResolver = store_IdResolver

--- a/tests/astrobot/conftest.py
+++ b/tests/astrobot/conftest.py
@@ -1,8 +1,6 @@
 import pytest
 from atproto import IdResolver
 
-import astrobot.commands.moderation.ban
-
 
 class MockIdResolver(IdResolver):
     """atproto IdResolver replacement that uses mock handle resolver to avoid network checks for handle resolution"""
@@ -47,12 +45,5 @@ class MockIdResolver(IdResolver):
 
 @pytest.fixture(scope="function")
 def mock_idresolver():
-    """replace each test's ban command's IdResolver with the mock class, and yield an instance to the test"""
-    store_IdResolver = astrobot.commands.moderation.ban.IdResolver
-    astrobot.commands.moderation.ban.IdResolver = MockIdResolver
-
-    # send an instance of the mock class to the test so that it can easily add mappings as it needs
-    yield MockIdResolver(timeout=30)
-
-    # cleanup; put original IdResolver back
-    astrobot.commands.moderation.ban.IdResolver = store_IdResolver
+    """Sends a separate instance of our mock IdResolver class to each test"""
+    return MockIdResolver(timeout=30)

--- a/tests/astrobot/conftest.py
+++ b/tests/astrobot/conftest.py
@@ -3,49 +3,51 @@ from atproto import IdResolver
 
 import astrobot.commands.moderation.ban
 
+
 class MockIdResolver(IdResolver):
-    '''atproto IdResolver replacement that uses mock handle resolver to avoid network checks for handle resolution'''
-    # class variable to store handle -> DID mappings; this needs to be a class (static) variable 
-    # because the command creates its own instance of this class during execution, so we need to 
+    """atproto IdResolver replacement that uses mock handle resolver to avoid network checks for handle resolution"""
+
+    # class variable to store handle -> DID mappings; this needs to be a class (static) variable
+    # because the command creates its own instance of this class during execution, so we need to
     # be able to modify this in a way that all instances (including as-yet-uncreated ones) will see
     handle_to_did = dict()
 
-    def __init__(self, plc_url = None, timeout = None, cache = None, backup_nameservers = None):
+    def __init__(self, plc_url=None, timeout=None, cache=None, backup_nameservers=None):
         super().__init__(plc_url, timeout, cache, backup_nameservers)
 
         # replace our handle resolver's resolve method with one that uses our internal mappings
         self.handle.resolve = self.mock_resolve
 
     def add_mapping(self, handle: str, did: str):
-        '''Adds a new handle -> DID entry into the local dictionary'''
-        handle = handle.lower() # everything is done in lowercased strings for Bsky
+        """Adds a new handle -> DID entry into the local dictionary"""
+        handle = handle.lower()  # everything is done in lowercased strings for Bsky
 
         # if handle isn't already present or the DID is different, make the change
         if handle not in self.handle_to_did.keys() or self.handle_to_did[handle] != did:
-            self.handle_to_did.update({handle:did})
+            self.handle_to_did.update({handle: did})
 
     def remove_mapping_by_handle(self, handle: str):
-        '''Removes an existing handle -> DID entry from the local dictionary'''
+        """Removes an existing handle -> DID entry from the local dictionary"""
         handle = handle.lower()
         if handle in self.handle_to_did.keys():
             del self.handle_to_did[handle]
-            
 
     def mock_resolve(self, handle):
-        '''Behaves like HandleResolver.resolve, except uses internal mappings rather than network lookup
-        
-        Checks for presence of requested handle in dictionary keys first, and returns None if not present; 
-        to avoid a KeyError and simply return None in the result of no match, to replicate behavior of 
+        """Behaves like HandleResolver.resolve, except uses internal mappings rather than network lookup
+
+        Checks for presence of requested handle in dictionary keys first, and returns None if not present;
+        to avoid a KeyError and simply return None in the result of no match, to replicate behavior of
         mocked method.
-        '''
+        """
         if handle in self.handle_to_did.keys():
             return self.handle_to_did[handle]
         else:
             return None
 
+
 @pytest.fixture(scope="function")
 def mock_idresolver():
-    '''replace each test's ban command's IdResolver with the mock class, and yield an instance to the test'''
+    """replace each test's ban command's IdResolver with the mock class, and yield an instance to the test"""
     store_IdResolver = astrobot.commands.moderation.ban.IdResolver
     astrobot.commands.moderation.ban.IdResolver = MockIdResolver
 

--- a/tests/astrobot/conftest.py
+++ b/tests/astrobot/conftest.py
@@ -5,7 +5,9 @@ import astrobot.commands.moderation.ban
 
 class MockIdResolver(IdResolver):
     '''atproto IdResolver replacement that uses mock handle resolver to avoid network checks for handle resolution'''
-    # class variable to store handle -> DID mappings
+    # class variable to store handle -> DID mappings; this needs to be a class (static) variable 
+    # because the command creates its own instance of this class during execution, so we need to 
+    # be able to modify this in a way that all instances (including as-yet-uncreated ones) will see
     handle_to_did = dict()
 
     def __init__(self, plc_url = None, timeout = None, cache = None, backup_nameservers = None):

--- a/tests/astrobot/test_command_ban.py
+++ b/tests/astrobot/test_command_ban.py
@@ -1,0 +1,537 @@
+#from dataclasses import asdict
+
+from astrofeed_lib.database import BotActions, ModActions, Post, Account
+from astrofeed_lib.database import DBConnection
+
+from astrobot.commands.moderation.ban import ModeratorBanCommand
+from astrobot.notifications import MentionNotification
+from astrobot.generate_notification import build_notification, build_reply_ref
+from astrobot.config import HANDLE
+from tests.test_lib.test_database import (
+    testdb_account_entry,
+    testdb_post_entry,
+    generate_testdb_post_by_author,
+)
+from tests.test_lib.test_util import check_call_signature, check_botactions_entry, check_modactions_entry
+
+
+#
+# utility functions
+#
+
+
+# cannot be fixtures, unfortunately, since each test needs to specify target post and author differently
+def get_ban_command_by_post(
+    target_post: Post | testdb_post_entry,
+    moderator_account: Account | testdb_account_entry,
+):
+    """Builds a ban command object given either a target post or a target user, and a moderator account."""
+    # we don't store root uri and cid in our Post table, leaving those as default values
+    ban_reply_ref = build_reply_ref(
+        parent_ref_cid=target_post.cid, parent_ref_uri=target_post.uri
+    )
+    ban_notification = build_notification(
+        "mention reply",
+        record_text=f"@{HANDLE} ban",
+        record_reply=ban_reply_ref,
+        author_did=moderator_account.did,
+    )
+    return ModeratorBanCommand(MentionNotification(ban_notification))
+
+def get_ban_command_by_user(
+    target_user: Account | testdb_account_entry,
+    moderator_account: Account | testdb_account_entry,
+):
+    """Builds a ban command object given a target user and a moderator account."""
+    ban_notification = build_notification(
+        "mention",
+        record_text=f"@{HANDLE} ban @{target_user.handle}",
+        author_did=moderator_account.did,
+    )
+    return ModeratorBanCommand(MentionNotification(ban_notification))
+
+
+#
+# test functions
+#
+
+def test_success_reply(test_db_conn, mock_client, mock_idresolver):
+    """Tests success case in which ban command replied to post of user to ban
+
+    After command execution, the targeted user's Account entry (the one associated with 
+    the replied-to post) should have banned=True, and have its banned_count field 
+    incremented by one; there should be a new BotAction and ModAction entry created, 
+    with appropriate information; and a Bluesky API call should have been made, to send 
+    a post to the instigating moderator informing them of action success.
+    """
+    # connect & collect
+    with DBConnection():
+        moderator_account = Account.select().where(
+            Account.mod_level >= ModeratorBanCommand.level
+        )[0]  # need a mod of high enough level
+        target_post_before = Post.select().where(Post.author != moderator_account.did)[0]
+        author_account_before = Account.select().where(
+            Account.did == target_post_before.author
+        )[0]
+
+    # set up successful mock ID resolution
+    mock_idresolver.add_mapping(author_account_before.handle, author_account_before.did)
+
+    # get our hide command
+    ban_command = get_ban_command_by_post(target_post_before, moderator_account)
+
+    # act
+    ban_command.execute(mock_client)
+
+    # post-act connect & collect
+    with DBConnection():
+        author_account_after = Account.select().where(
+            Account.did == author_account_before.did
+        )[0]
+        botaction = BotActions.select().where(
+            BotActions.parent_uri == ban_command.notification.parent_ref.uri
+        )[0]
+        modaction = (
+            ModActions.select()
+            .where(
+                (ModActions.did_mod == moderator_account.did)
+                & (ModActions.did_user == author_account_before.did)
+            )
+            .order_by(ModActions.indexed_at.desc())[0]
+        )
+
+    # checks
+    assert author_account_after.is_banned
+    assert author_account_after.banned_count == author_account_before.banned_count + 1
+
+    # do posts get hidden automatically when a user is banned?
+
+    check_call_signature(
+        command=ban_command,
+        mock_client=mock_client,
+        text="User banned from feeds successfully.",
+    )
+    check_botactions_entry(
+        command=ban_command, 
+        botaction=botaction,
+    )
+    check_modactions_entry(
+        command=ban_command, 
+        did_user=author_account_before.did, 
+        modaction=modaction,
+    )
+
+def test_success_mention(test_db_conn, mock_client, mock_idresolver):
+    """Tests success case in which ban command explicitly named (by handle) user to ban
+
+    After command execution, the targeted user's Account entry (the one associated with 
+    the replied-to post) should have banned=True, and have its banned_count field 
+    incremented by one; there should be a new BotAction and ModAction entry created, 
+    with appropriate information; and a Bluesky API call should have been made, to send 
+    a post to the instigating moderator informing them of action success.
+    """
+    # connect & collect
+    with DBConnection():
+        moderator_account = Account.select().where(
+            Account.mod_level >= ModeratorBanCommand.level
+        )[0]  # need a mod of high enough level
+        target_account_before = Account.select().where(Account.did != moderator_account.did)[0]
+
+    # set up successful mock ID resolution
+    mock_idresolver.add_mapping(target_account_before.handle, target_account_before.did)
+
+    # get our hide command
+    ban_command = get_ban_command_by_user(target_account_before, moderator_account)
+
+    # act
+    ban_command.execute(mock_client)
+
+    # post-act connect & collect
+    with DBConnection():
+        target_account_after = Account.select().where(
+            Account.did == target_account_before.did
+        )[0]
+        botaction = BotActions.select().where(
+            BotActions.parent_uri == ban_command.notification.parent_ref.uri
+        )[0]
+        modaction = (
+            ModActions.select()
+            .where(
+                (ModActions.did_mod == moderator_account.did)
+                & (ModActions.did_user == target_account_before.did)
+            )
+            .order_by(ModActions.indexed_at.desc())[0]
+        )
+
+    # checks
+    assert target_account_after.is_banned
+    assert target_account_after.banned_count == target_account_before.banned_count + 1
+
+    # do posts get hidden automatically when a user is banned?
+
+    check_call_signature(
+        command=ban_command,
+        mock_client=mock_client,
+        text="User banned from feeds successfully.",
+    )
+    check_botactions_entry(
+        command=ban_command, 
+        botaction=botaction,
+    )
+    check_modactions_entry(
+        command=ban_command, 
+        did_user=target_account_before.did, 
+        modaction=modaction,
+    )
+
+def test_success_multiple_author_entries(test_db_conn, mock_client, mock_idresolver):
+    """Tests success case in which user to ban has multiple entries in Account table
+
+    Note: for this and futures cases, it doesn't matter whether we take the "reply" or
+    "mention" path, as beyond the reply vs mention decision point, they will both make 
+    the same function call.
+    
+    After command execution, every one of the Account entries associated with the target 
+    user should have banned=True, and they should *all* have their banned_count field 
+    set to one higher than the banned_count of whichever entry had the maximum 
+    banned_count before command execution; there should be a new BotAction and ModAction 
+    entry created, with appropriate information; and a Bluesky API call should have been 
+    made, to send a post to the instigating moderator informing them of action success.
+    """
+    # connect & collect
+    with DBConnection() as conn:
+        moderator_account = Account.select().where(
+            Account.mod_level >= ModeratorBanCommand.level
+        )[0]  # need a high enough level
+        target_post_before = Post.select().where(Post.author != moderator_account.did)[0]
+
+        # Need to duplicate our target author a few times, with specific properties:
+        #   * we want some duplicate entries to already be banned, and some not; 
+        #   * and we want them to have different banned_counts
+        # This will allow us to test that all entries, regardless of initial state, 
+        # are banned at the end; and that they all get the correct banned_count
+        author_account_dict = Account.select().where(
+            Account.did == target_post_before.author
+        ).dicts()[0]
+        max_account_id = Account.select().order_by(Account.id.desc())[0].id
+        base_banned_count = author_account_dict["banned_count"]
+        for i in [1, 2]:
+            author_account_dict["id"] = max_account_id + i # guarantee unique id per entry
+            author_account_dict["is_banned"] = i%2 == 0 # one already banned, one not
+            author_account_dict["banned_count"] = base_banned_count + i # three different banned counts
+            with conn.atomic():
+                Account.insert(author_account_dict).execute()
+        author_duplicates_before = list(
+            Account.select().where(Account.did == author_account_dict["did"])
+        )
+        max_banned_count_before = max([account.banned_count for account in author_duplicates_before])
+
+
+    # set up successful mock ID resolution
+    mock_idresolver.add_mapping(author_account_dict["handle"], author_account_dict["did"])
+
+    # get our hide command
+    ban_command = get_ban_command_by_post(target_post_before, moderator_account)
+
+    # act
+    ban_command.execute(mock_client)
+
+    # post-act connect & collect
+    with DBConnection():
+        author_duplicates_after = list(
+            Account.select().where(Account.did == author_account_dict["did"])
+        )
+        botaction = BotActions.select().where(
+            BotActions.parent_uri == ban_command.notification.parent_ref.uri
+        )[0]
+        modaction = (
+            ModActions.select()
+            .where(
+                (ModActions.did_mod == moderator_account.did)
+                & (ModActions.did_user == author_account_dict["did"])
+            )
+            .order_by(ModActions.indexed_at.desc())[0]
+        )
+
+    # checks
+    for account in author_duplicates_after:
+        assert account.is_banned
+        assert account.banned_count == max_banned_count_before + 1
+
+    # do posts get hidden automatically when a user is banned?
+
+    check_call_signature(
+        command=ban_command,
+        mock_client=mock_client,
+        text="User banned from feeds successfully.",
+    )
+    check_botactions_entry(
+        command=ban_command, 
+        botaction=botaction,
+    )
+    check_modactions_entry(
+        command=ban_command, 
+        did_user=author_account_dict["did"], 
+        modaction=modaction,
+    )
+
+
+
+def test_failure_insufficient_mod_level(test_db_conn, mock_client, mock_idresolver):
+    """Tests failure case in which instigating account has insufficient mod access.
+
+    In this case, no modification should be made to any Account entry; no ModAction
+    entry should be created, and a BotAction entry should be created with 
+    authorized=False; and a Bluesky API call should be made to send a post to the 
+    instigating account indicating action failure, and the reason for the failure.
+    """
+    # connect & collect
+    with DBConnection():
+        moderator_account = Account.select().where(
+            Account.mod_level < ModeratorBanCommand.level
+        )[0]  # need a mod of too low a level
+        target_post_before = Post.select().where(Post.author != moderator_account.did)[0]
+        author_account_before = Account.select().where(
+            Account.did == target_post_before.author
+        )[0]
+        latest_modaction_before = ModActions.select().order_by(
+            ModActions.indexed_at.desc()
+        )[0]
+
+    # set up successful mock ID resolution
+    mock_idresolver.add_mapping(author_account_before.handle, author_account_before.did)
+
+    # get our hide command
+    ban_command = get_ban_command_by_post(target_post_before, moderator_account)
+
+    # act
+    ban_command.execute(mock_client)
+
+    # post-act connect & collect
+    with DBConnection():
+        author_account_after = Account.select().where(
+            Account.did == author_account_before.did
+        )[0]
+        botaction = BotActions.select().where(
+            BotActions.parent_uri == ban_command.notification.parent_ref.uri
+        )[0]
+        n_modactions = (
+            ModActions.select()
+            .where(
+                (ModActions.did_mod == moderator_account.did)
+                & (ModActions.did_user == author_account_before.did)
+                & (ModActions.indexed_at > latest_modaction_before.indexed_at)
+            )
+            .count()
+        )
+
+    # checks
+    assert not author_account_after.is_banned
+    assert author_account_after.banned_count == author_account_before.banned_count
+    assert n_modactions == 0
+
+    check_call_signature(
+        command=ban_command,
+        mock_client=mock_client,
+        text=f"Sorry, but you don't have the required permissions to run this command. Reason: Lacking required moderator level ({ban_command.level})",
+    )
+    check_botactions_entry(
+        command=ban_command, 
+        botaction=botaction,
+    )
+
+
+def test_failure_cannot_resolve_handle_to_ban(test_db_conn, mock_client, mock_idresolver):
+    """Tests failure case in which the handle specified to ban in a mention cannot be resolved
+    
+    In this case, no modification should be made to any Account entry; no ModAction
+    entry should be created, and a BotAction entry should be created as usual; and 
+    a Bluesky API call should be made to send a post to the instigating account 
+    indicating action failure, and the reason for the failure.
+    """
+    with DBConnection():
+        moderator_account = Account.select().where(
+            Account.mod_level >= ModeratorBanCommand.level
+        )[0]  # need a mod of high enough level
+        target_account_before = Account.select().where(Account.did != moderator_account.did)[0]
+        latest_modaction_before = ModActions.select().order_by(
+            ModActions.indexed_at.desc()
+        )[0]
+
+    # make sure that the handle will not resolve succesfully
+    mock_idresolver.remove_mapping_by_handle(target_account_before.handle)
+
+    # get our hide command
+    ban_command = get_ban_command_by_user(target_account_before, moderator_account)
+
+    # act
+    ban_command.execute(mock_client)
+
+    # post-act connect & collect
+    with DBConnection():
+        target_account_after = Account.select().where(
+            Account.did == target_account_before.did
+        )[0]
+        botaction = BotActions.select().where(
+            BotActions.parent_uri == ban_command.notification.parent_ref.uri
+        )[0]
+        n_modactions = (
+            ModActions.select()
+            .where(
+                (ModActions.did_mod == moderator_account.did)
+                & (ModActions.did_user == target_account_before.did)
+                & (ModActions.indexed_at > latest_modaction_before.indexed_at)
+            )
+            .count()
+        )
+
+    # checks
+    assert target_account_after.is_banned == target_account_before.is_banned
+    assert target_account_after.banned_count == target_account_before.banned_count
+    assert n_modactions == 0
+
+    # do posts get hidden automatically when a user is banned?
+
+    check_call_signature(
+        command=ban_command,
+        mock_client=mock_client,
+        text=f"Unable to execute ban; not able to resolve given user handle \"{ban_command.notification.words[1][1:]}\"",
+    )
+    check_botactions_entry(
+        command=ban_command, 
+        botaction=botaction,
+    )
+
+def test_failure_user_not_signed_up(test_db_conn, mock_client, mock_idresolver):
+    """Tests failure case in which target user is not signed up to post in feeds.
+    
+    In this case, no modification should be made to any Account entry; no ModAction
+    entry should be created, and a BotAction entry should be created as usual; and 
+    a Bluesky API call should be made to send a post to the instigating account 
+    indicating action failure, and the reason for the failure.
+    """
+    # create an author who will not be entered into the database, and a post by them that will not
+    unregistered_author = testdb_account_entry(
+        handle="Dasha", did="did:plc:DDDDDDDDDDDDDDDDDDDDDDDD"
+    )
+    target_post = generate_testdb_post_by_author(
+        text="astronomy is neato", author=unregistered_author
+    )
+
+    # connect & collect
+    with DBConnection():
+        moderator_account = Account.select().where(
+            Account.mod_level > ModeratorBanCommand.level
+        )[0]  # need a mod of high enough level
+        latest_modaction_before = ModActions.select().order_by(
+            ModActions.indexed_at.desc()
+        )[0]
+
+    # set up successful mock ID resolution
+    mock_idresolver.add_mapping(unregistered_author.handle, unregistered_author.did)
+
+    # get our hide command
+    ban_command = get_ban_command_by_post(target_post, moderator_account)
+
+    # act
+    ban_command.execute(mock_client)
+
+    # post-act connect & collect
+    with DBConnection():
+        botaction = BotActions.select().where(
+            BotActions.parent_uri == ban_command.notification.parent_ref.uri
+        )[0]
+        n_modactions = (
+            ModActions.select()
+            .where(
+                (ModActions.did_mod == moderator_account.did)
+                & (ModActions.did_user == unregistered_author.did)
+                & (ModActions.indexed_at > latest_modaction_before.indexed_at)
+            )
+            .count()
+        )
+
+    # checks
+    assert n_modactions == 0
+
+    check_call_signature(
+        command=ban_command,
+        mock_client=mock_client,
+        text="Unable to ban user: user is not signed up to the feeds.",
+    )
+    check_botactions_entry(
+        command=ban_command, 
+        botaction=botaction,
+    )
+
+
+def test_failure_user_already_banned(test_db_conn, mock_client, mock_idresolver):
+    """Tests failure case in which target user is already banned from feeds.
+    
+    In this case, no modification should be made to any Account entry (with all 
+    Account entries for target user remaining banned); no ModAction entry should 
+    be created, and a BotAction entry should be created as usual; and a Bluesky 
+    API call should be made to send a post to the instigating account indicating 
+    action failure, and the reason for the failure.
+    """
+    # connect & collect
+    with DBConnection():
+        moderator_account = Account.select().where(
+            Account.mod_level >= ModeratorBanCommand.level
+        )[0]  # need a mod of high enough level
+        target_post_before = Post.select().where(Post.author != moderator_account.did)[0]
+        latest_modaction_before = ModActions.select().order_by(
+            ModActions.indexed_at.desc()
+        )[0]
+
+        # modify our author account to make it banned already
+        author_account_before = Account.select().where(
+            Account.did == target_post_before.author
+        )[0]
+        author_account_before.is_banned = True
+        author_account_before.banned_count = 1
+        author_account_before.save()
+
+    # set up successful mock ID resolution
+    mock_idresolver.add_mapping(author_account_before.handle, author_account_before.did)
+
+    # get our hide command
+    ban_command = get_ban_command_by_post(target_post_before, moderator_account)
+
+    # act
+    ban_command.execute(mock_client)
+
+    # post-act connect & collect
+    with DBConnection():
+        author_account_after = Account.select().where(
+            Account.did == author_account_before.did
+        )[0]
+        botaction = BotActions.select().where(
+            BotActions.parent_uri == ban_command.notification.parent_ref.uri
+        )[0]
+        n_modactions = (
+            ModActions.select()
+            .where(
+                (ModActions.did_mod == moderator_account.did)
+                & (ModActions.did_user == author_account_before.did)
+                & (ModActions.indexed_at > latest_modaction_before.indexed_at)
+            )
+            .count()
+        )
+
+    # checks
+    assert author_account_after.is_banned
+    assert author_account_after.banned_count == author_account_before.banned_count
+    assert n_modactions == 0
+
+    # do posts get hidden automatically when a user is banned?
+
+    check_call_signature(
+        command=ban_command,
+        mock_client=mock_client,
+        text="Unable to ban user: user already banned.",
+    )
+    check_botactions_entry(
+        command=ban_command, 
+        botaction=botaction,
+    )

--- a/tests/astrobot/test_command_ban.py
+++ b/tests/astrobot/test_command_ban.py
@@ -13,7 +13,7 @@ from tests.test_lib.test_util import (
     check_botactions_entry,
     check_modactions_entry,
 )
-
+from tests.astrobot.conftest import MockIdResolver
 
 #
 # utility functions
@@ -23,6 +23,7 @@ from tests.test_lib.test_util import (
 def get_ban_command(
     target_user: Account | testdb_account_entry,
     moderator_account: Account | testdb_account_entry,
+    id_resolver: MockIdResolver,
 ):
     """Builds a ban command object given target user and moderator accounts."""
     ban_notification = build_notification(
@@ -30,7 +31,7 @@ def get_ban_command(
         record_text=f"@{HANDLE} ban {target_user.handle}",
         author_did=moderator_account.did,
     )
-    return ModeratorBanCommand(MentionNotification(ban_notification))
+    return ModeratorBanCommand(MentionNotification(ban_notification), id_resolver)
 
 
 #
@@ -60,7 +61,9 @@ def test_success(test_db_conn, mock_client, mock_idresolver):
     mock_idresolver.add_mapping(target_account_before.handle, target_account_before.did)
 
     # get our ban command
-    ban_command = get_ban_command(target_account_before, moderator_account)
+    ban_command = get_ban_command(
+        target_account_before, moderator_account, mock_idresolver
+    )
 
     # act
     ban_command.execute(mock_client)
@@ -150,7 +153,9 @@ def test_success_multiple_author_entries(test_db_conn, mock_client, mock_idresol
     mock_idresolver.add_mapping(target_account_before.handle, target_account_before.did)
 
     # get our ban command
-    ban_command = get_ban_command(target_account_before, moderator_account)
+    ban_command = get_ban_command(
+        target_account_before, moderator_account, mock_idresolver
+    )
 
     # act
     ban_command.execute(mock_client)
@@ -217,7 +222,9 @@ def test_failure_insufficient_mod_level(test_db_conn, mock_client, mock_idresolv
     mock_idresolver.add_mapping(target_account_before.handle, target_account_before.did)
 
     # get our ban command
-    ban_command = get_ban_command(target_account_before, moderator_account)
+    ban_command = get_ban_command(
+        target_account_before, moderator_account, mock_idresolver
+    )
 
     # act
     ban_command.execute(mock_client)
@@ -279,7 +286,9 @@ def test_failure_no_handle_provided(test_db_conn, mock_client, mock_idresolver):
         record_text=f"@{HANDLE} ban",
         author_did=moderator_account.did,
     )
-    ban_command = ModeratorBanCommand(MentionNotification(ban_notification))
+    ban_command = ModeratorBanCommand(
+        MentionNotification(ban_notification), mock_idresolver
+    )
 
     # act
     ban_command.execute(mock_client)
@@ -337,7 +346,9 @@ def test_failure_cannot_resolve_handle_to_ban(
     mock_idresolver.remove_mapping_by_handle(target_account_before.handle)
 
     # get our ban command
-    ban_command = get_ban_command(target_account_before, moderator_account)
+    ban_command = get_ban_command(
+        target_account_before, moderator_account, mock_idresolver
+    )
 
     # act
     ban_command.execute(mock_client)
@@ -402,7 +413,7 @@ def test_failure_user_not_signed_up(test_db_conn, mock_client, mock_idresolver):
     mock_idresolver.add_mapping(unregistered_user.handle, unregistered_user.did)
 
     # get our ban command
-    ban_command = get_ban_command(unregistered_user, moderator_account)
+    ban_command = get_ban_command(unregistered_user, moderator_account, mock_idresolver)
 
     # act
     ban_command.execute(mock_client)
@@ -466,7 +477,9 @@ def test_failure_user_already_banned(test_db_conn, mock_client, mock_idresolver)
     mock_idresolver.add_mapping(target_account_before.handle, target_account_before.did)
 
     # get our ban command
-    ban_command = get_ban_command(target_account_before, moderator_account)
+    ban_command = get_ban_command(
+        target_account_before, moderator_account, mock_idresolver
+    )
 
     # act
     ban_command.execute(mock_client)

--- a/tests/astrobot/test_command_ban.py
+++ b/tests/astrobot/test_command_ban.py
@@ -1,16 +1,14 @@
 #from dataclasses import asdict
 
-from astrofeed_lib.database import BotActions, ModActions, Post, Account
+from astrofeed_lib.database import BotActions, ModActions, Account
 from astrofeed_lib.database import DBConnection
 
 from astrobot.commands.moderation.ban import ModeratorBanCommand
 from astrobot.notifications import MentionNotification
-from astrobot.generate_notification import build_notification, build_reply_ref
+from astrobot.generate_notification import build_notification
 from astrobot.config import HANDLE
 from tests.test_lib.test_database import (
     testdb_account_entry,
-    testdb_post_entry,
-    generate_testdb_post_by_author,
 )
 from tests.test_lib.test_util import check_call_signature, check_botactions_entry, check_modactions_entry
 
@@ -21,31 +19,15 @@ from tests.test_lib.test_util import check_call_signature, check_botactions_entr
 
 
 # cannot be fixtures, unfortunately, since each test needs to specify target post and author differently
-def get_ban_command_by_post(
-    target_post: Post | testdb_post_entry,
-    moderator_account: Account | testdb_account_entry,
-):
-    """Builds a ban command object given either a target post or a target user, and a moderator account."""
-    # we don't store root uri and cid in our Post table, leaving those as default values
-    ban_reply_ref = build_reply_ref(
-        parent_ref_cid=target_post.cid, parent_ref_uri=target_post.uri
-    )
-    ban_notification = build_notification(
-        "mention reply",
-        record_text=f"@{HANDLE} ban",
-        record_reply=ban_reply_ref,
-        author_did=moderator_account.did,
-    )
-    return ModeratorBanCommand(MentionNotification(ban_notification))
 
-def get_ban_command_by_user(
+def get_ban_command(
     target_user: Account | testdb_account_entry,
     moderator_account: Account | testdb_account_entry,
 ):
     """Builds a ban command object given a target user and a moderator account."""
     ban_notification = build_notification(
         "mention",
-        record_text=f"@{HANDLE} ban @{target_user.handle}",
+        record_text=f"@{HANDLE} ban {target_user.handle}",
         author_did=moderator_account.did,
     )
     return ModeratorBanCommand(MentionNotification(ban_notification))
@@ -55,73 +37,8 @@ def get_ban_command_by_user(
 # test functions
 #
 
-def test_success_reply(test_db_conn, mock_client, mock_idresolver):
-    """Tests success case in which ban command replied to post of user to ban
 
-    After command execution, the targeted user's Account entry (the one associated with 
-    the replied-to post) should have banned=True, and have its banned_count field 
-    incremented by one; there should be a new BotAction and ModAction entry created, 
-    with appropriate information; and a Bluesky API call should have been made, to send 
-    a post to the instigating moderator informing them of action success.
-    """
-    # connect & collect
-    with DBConnection():
-        moderator_account = Account.select().where(
-            Account.mod_level >= ModeratorBanCommand.level
-        )[0]  # need a mod of high enough level
-        target_post_before = Post.select().where(Post.author != moderator_account.did)[0]
-        author_account_before = Account.select().where(
-            Account.did == target_post_before.author
-        )[0]
-
-    # set up successful mock ID resolution
-    mock_idresolver.add_mapping(author_account_before.handle, author_account_before.did)
-
-    # get our hide command
-    ban_command = get_ban_command_by_post(target_post_before, moderator_account)
-
-    # act
-    ban_command.execute(mock_client)
-
-    # post-act connect & collect
-    with DBConnection():
-        author_account_after = Account.select().where(
-            Account.did == author_account_before.did
-        )[0]
-        botaction = BotActions.select().where(
-            BotActions.parent_uri == ban_command.notification.parent_ref.uri
-        )[0]
-        modaction = (
-            ModActions.select()
-            .where(
-                (ModActions.did_mod == moderator_account.did)
-                & (ModActions.did_user == author_account_before.did)
-            )
-            .order_by(ModActions.indexed_at.desc())[0]
-        )
-
-    # checks
-    assert author_account_after.is_banned
-    assert author_account_after.banned_count == author_account_before.banned_count + 1
-
-    # do posts get hidden automatically when a user is banned?
-
-    check_call_signature(
-        command=ban_command,
-        mock_client=mock_client,
-        text="User banned from feeds successfully.",
-    )
-    check_botactions_entry(
-        command=ban_command, 
-        botaction=botaction,
-    )
-    check_modactions_entry(
-        command=ban_command, 
-        did_user=author_account_before.did, 
-        modaction=modaction,
-    )
-
-def test_success_mention(test_db_conn, mock_client, mock_idresolver):
+def test_success(test_db_conn, mock_client, mock_idresolver):
     """Tests success case in which ban command explicitly named (by handle) user to ban
 
     After command execution, the targeted user's Account entry (the one associated with 
@@ -140,8 +57,8 @@ def test_success_mention(test_db_conn, mock_client, mock_idresolver):
     # set up successful mock ID resolution
     mock_idresolver.add_mapping(target_account_before.handle, target_account_before.did)
 
-    # get our hide command
-    ban_command = get_ban_command_by_user(target_account_before, moderator_account)
+    # get our ban command
+    ban_command = get_ban_command(target_account_before, moderator_account)
 
     # act
     ban_command.execute(mock_client)
@@ -203,43 +120,41 @@ def test_success_multiple_author_entries(test_db_conn, mock_client, mock_idresol
         moderator_account = Account.select().where(
             Account.mod_level >= ModeratorBanCommand.level
         )[0]  # need a high enough level
-        target_post_before = Post.select().where(Post.author != moderator_account.did)[0]
+        target_account_before = Account.select().where(Account.did != moderator_account.did)[0]
 
         # Need to duplicate our target author a few times, with specific properties:
         #   * we want some duplicate entries to already be banned, and some not; 
         #   * and we want them to have different banned_counts
         # This will allow us to test that all entries, regardless of initial state, 
         # are banned at the end; and that they all get the correct banned_count
-        author_account_dict = Account.select().where(
-            Account.did == target_post_before.author
-        ).dicts()[0]
+        target_account_dict = target_account_before.__dict__["__data__"]
         max_account_id = Account.select().order_by(Account.id.desc())[0].id
-        base_banned_count = author_account_dict["banned_count"]
+        base_banned_count = target_account_dict["banned_count"]
         for i in [1, 2]:
-            author_account_dict["id"] = max_account_id + i # guarantee unique id per entry
-            author_account_dict["is_banned"] = i%2 == 0 # one already banned, one not
-            author_account_dict["banned_count"] = base_banned_count + i # three different banned counts
+            target_account_dict["id"] = max_account_id + i # guarantee unique id per entry
+            target_account_dict["is_banned"] = i%2 == 0 # one already banned, one not
+            target_account_dict["banned_count"] = base_banned_count + i # three different banned counts
             with conn.atomic():
-                Account.insert(author_account_dict).execute()
-        author_duplicates_before = list(
-            Account.select().where(Account.did == author_account_dict["did"])
+                Account.insert(target_account_dict).execute()
+        target_duplicates_before = list(
+            Account.select().where(Account.did == target_account_before.did)
         )
-        max_banned_count_before = max([account.banned_count for account in author_duplicates_before])
+        max_banned_count_before = max([account.banned_count for account in target_duplicates_before])
 
 
     # set up successful mock ID resolution
-    mock_idresolver.add_mapping(author_account_dict["handle"], author_account_dict["did"])
+    mock_idresolver.add_mapping(target_account_before.handle, target_account_before.did)
 
-    # get our hide command
-    ban_command = get_ban_command_by_post(target_post_before, moderator_account)
+    # get our ban command
+    ban_command = get_ban_command(target_account_before, moderator_account)
 
     # act
     ban_command.execute(mock_client)
 
     # post-act connect & collect
     with DBConnection():
-        author_duplicates_after = list(
-            Account.select().where(Account.did == author_account_dict["did"])
+        target_duplicates_after = list(
+            Account.select().where(Account.did == target_account_before.did)
         )
         botaction = BotActions.select().where(
             BotActions.parent_uri == ban_command.notification.parent_ref.uri
@@ -248,13 +163,13 @@ def test_success_multiple_author_entries(test_db_conn, mock_client, mock_idresol
             ModActions.select()
             .where(
                 (ModActions.did_mod == moderator_account.did)
-                & (ModActions.did_user == author_account_dict["did"])
+                & (ModActions.did_user == target_account_before.did)
             )
             .order_by(ModActions.indexed_at.desc())[0]
         )
 
     # checks
-    for account in author_duplicates_after:
+    for account in target_duplicates_after:
         assert account.is_banned
         assert account.banned_count == max_banned_count_before + 1
 
@@ -271,7 +186,7 @@ def test_success_multiple_author_entries(test_db_conn, mock_client, mock_idresol
     )
     check_modactions_entry(
         command=ban_command, 
-        did_user=author_account_dict["did"], 
+        did_user=target_account_before.did, 
         modaction=modaction,
     )
 
@@ -290,27 +205,24 @@ def test_failure_insufficient_mod_level(test_db_conn, mock_client, mock_idresolv
         moderator_account = Account.select().where(
             Account.mod_level < ModeratorBanCommand.level
         )[0]  # need a mod of too low a level
-        target_post_before = Post.select().where(Post.author != moderator_account.did)[0]
-        author_account_before = Account.select().where(
-            Account.did == target_post_before.author
-        )[0]
+        target_account_before = Account.select().where(Account.did != moderator_account.did)[0]
         latest_modaction_before = ModActions.select().order_by(
             ModActions.indexed_at.desc()
         )[0]
 
     # set up successful mock ID resolution
-    mock_idresolver.add_mapping(author_account_before.handle, author_account_before.did)
+    mock_idresolver.add_mapping(target_account_before.handle, target_account_before.did)
 
-    # get our hide command
-    ban_command = get_ban_command_by_post(target_post_before, moderator_account)
+    # get our ban command
+    ban_command = get_ban_command(target_account_before, moderator_account)
 
     # act
     ban_command.execute(mock_client)
 
     # post-act connect & collect
     with DBConnection():
-        author_account_after = Account.select().where(
-            Account.did == author_account_before.did
+        target_account_after = Account.select().where(
+            Account.did == target_account_before.did
         )[0]
         botaction = BotActions.select().where(
             BotActions.parent_uri == ban_command.notification.parent_ref.uri
@@ -319,15 +231,15 @@ def test_failure_insufficient_mod_level(test_db_conn, mock_client, mock_idresolv
             ModActions.select()
             .where(
                 (ModActions.did_mod == moderator_account.did)
-                & (ModActions.did_user == author_account_before.did)
+                & (ModActions.did_user == target_account_before.did)
                 & (ModActions.indexed_at > latest_modaction_before.indexed_at)
             )
             .count()
         )
 
     # checks
-    assert not author_account_after.is_banned
-    assert author_account_after.banned_count == author_account_before.banned_count
+    assert not target_account_after.is_banned
+    assert target_account_after.banned_count == target_account_before.banned_count
     assert n_modactions == 0
 
     check_call_signature(
@@ -361,8 +273,8 @@ def test_failure_cannot_resolve_handle_to_ban(test_db_conn, mock_client, mock_id
     # make sure that the handle will not resolve succesfully
     mock_idresolver.remove_mapping_by_handle(target_account_before.handle)
 
-    # get our hide command
-    ban_command = get_ban_command_by_user(target_account_before, moderator_account)
+    # get our ban command
+    ban_command = get_ban_command(target_account_before, moderator_account)
 
     # act
     ban_command.execute(mock_client)
@@ -395,7 +307,7 @@ def test_failure_cannot_resolve_handle_to_ban(test_db_conn, mock_client, mock_id
     check_call_signature(
         command=ban_command,
         mock_client=mock_client,
-        text=f"Unable to execute ban; not able to resolve given user handle \"{ban_command.notification.words[1][1:]}\"",
+        text=f"Unable to execute ban; not able to resolve given user handle \"{ban_command.notification.words[1]}\"",
     )
     check_botactions_entry(
         command=ban_command, 
@@ -411,11 +323,8 @@ def test_failure_user_not_signed_up(test_db_conn, mock_client, mock_idresolver):
     indicating action failure, and the reason for the failure.
     """
     # create an author who will not be entered into the database, and a post by them that will not
-    unregistered_author = testdb_account_entry(
+    unregistered_user = testdb_account_entry(
         handle="Dasha", did="did:plc:DDDDDDDDDDDDDDDDDDDDDDDD"
-    )
-    target_post = generate_testdb_post_by_author(
-        text="astronomy is neato", author=unregistered_author
     )
 
     # connect & collect
@@ -428,10 +337,10 @@ def test_failure_user_not_signed_up(test_db_conn, mock_client, mock_idresolver):
         )[0]
 
     # set up successful mock ID resolution
-    mock_idresolver.add_mapping(unregistered_author.handle, unregistered_author.did)
+    mock_idresolver.add_mapping(unregistered_user.handle, unregistered_user.did)
 
-    # get our hide command
-    ban_command = get_ban_command_by_post(target_post, moderator_account)
+    # get our ban command
+    ban_command = get_ban_command(unregistered_user, moderator_account)
 
     # act
     ban_command.execute(mock_client)
@@ -445,7 +354,7 @@ def test_failure_user_not_signed_up(test_db_conn, mock_client, mock_idresolver):
             ModActions.select()
             .where(
                 (ModActions.did_mod == moderator_account.did)
-                & (ModActions.did_user == unregistered_author.did)
+                & (ModActions.did_user == unregistered_user.did)
                 & (ModActions.indexed_at > latest_modaction_before.indexed_at)
             )
             .count()
@@ -479,32 +388,29 @@ def test_failure_user_already_banned(test_db_conn, mock_client, mock_idresolver)
         moderator_account = Account.select().where(
             Account.mod_level >= ModeratorBanCommand.level
         )[0]  # need a mod of high enough level
-        target_post_before = Post.select().where(Post.author != moderator_account.did)[0]
         latest_modaction_before = ModActions.select().order_by(
             ModActions.indexed_at.desc()
         )[0]
 
         # modify our author account to make it banned already
-        author_account_before = Account.select().where(
-            Account.did == target_post_before.author
-        )[0]
-        author_account_before.is_banned = True
-        author_account_before.banned_count = 1
-        author_account_before.save()
+        target_account_before = Account.select().where(Account.did != moderator_account.did)[0]
+        target_account_before.is_banned = True
+        target_account_before.banned_count = 1
+        target_account_before.save()
 
     # set up successful mock ID resolution
-    mock_idresolver.add_mapping(author_account_before.handle, author_account_before.did)
+    mock_idresolver.add_mapping(target_account_before.handle, target_account_before.did)
 
-    # get our hide command
-    ban_command = get_ban_command_by_post(target_post_before, moderator_account)
+    # get our ban command
+    ban_command = get_ban_command(target_account_before, moderator_account)
 
     # act
     ban_command.execute(mock_client)
 
     # post-act connect & collect
     with DBConnection():
-        author_account_after = Account.select().where(
-            Account.did == author_account_before.did
+        target_account_after = Account.select().where(
+            Account.did == target_account_before.did
         )[0]
         botaction = BotActions.select().where(
             BotActions.parent_uri == ban_command.notification.parent_ref.uri
@@ -513,15 +419,15 @@ def test_failure_user_already_banned(test_db_conn, mock_client, mock_idresolver)
             ModActions.select()
             .where(
                 (ModActions.did_mod == moderator_account.did)
-                & (ModActions.did_user == author_account_before.did)
+                & (ModActions.did_user == target_account_before.did)
                 & (ModActions.indexed_at > latest_modaction_before.indexed_at)
             )
             .count()
         )
 
     # checks
-    assert author_account_after.is_banned
-    assert author_account_after.banned_count == author_account_before.banned_count
+    assert target_account_after.is_banned
+    assert target_account_after.banned_count == target_account_before.banned_count
     assert n_modactions == 0
 
     # do posts get hidden automatically when a user is banned?

--- a/tests/astrobot/test_command_hide.py
+++ b/tests/astrobot/test_command_hide.py
@@ -12,7 +12,11 @@ from tests.test_lib.test_database import (
     testdb_post_entry,
     generate_testdb_post_by_author,
 )
-from tests.test_lib.test_util import check_call_signature, check_botactions_entry, check_modactions_entry
+from tests.test_lib.test_util import (
+    check_call_signature,
+    check_botactions_entry,
+    check_modactions_entry,
+)
 
 #
 # utility functions
@@ -96,12 +100,14 @@ def test_success(test_db_conn, mock_client):
         text="Post hidden from feeds successfully.",
     )
     check_botactions_entry(
-        command=hide_command, 
+        command=hide_command,
         botaction=botaction,
     )
     check_modactions_entry(
         command=hide_command,
-        did_user=hide_command.notification.notification.record.reply.parent.uri.replace("at://", "").split("/")[0],
+        did_user=hide_command.notification.notification.record.reply.parent.uri.replace(
+            "at://", ""
+        ).split("/")[0],
         modaction=modaction,
     )
 
@@ -182,12 +188,14 @@ def test_success_multiple_author_entries(test_db_conn, mock_client):
         text="Post hidden from feeds successfully.",
     )
     check_botactions_entry(
-        command=hide_command, 
+        command=hide_command,
         botaction=botaction,
     )
     check_modactions_entry(
         command=hide_command,
-        did_user=hide_command.notification.notification.record.reply.parent.uri.replace("at://", "").split("/")[0],
+        did_user=hide_command.notification.notification.record.reply.parent.uri.replace(
+            "at://", ""
+        ).split("/")[0],
         modaction=modaction,
     )
 
@@ -269,12 +277,14 @@ def test_success_multiple_post_entries(test_db_conn, mock_client):
         text="Post hidden from feeds successfully.",
     )
     check_botactions_entry(
-        command=hide_command, 
+        command=hide_command,
         botaction=botaction,
     )
     check_modactions_entry(
         command=hide_command,
-        did_user=hide_command.notification.notification.record.reply.parent.uri.replace("at://", "").split("/")[0],
+        did_user=hide_command.notification.notification.record.reply.parent.uri.replace(
+            "at://", ""
+        ).split("/")[0],
         modaction=modaction,
     )
 
@@ -337,7 +347,7 @@ def test_failure_insufficient_mod_level(test_db_conn, mock_client):
         text="Sorry, but you don't have the required permissions to run this command. Reason: Lacking required moderator level (2)",
     )
     check_botactions_entry(
-        command=hide_command, 
+        command=hide_command,
         botaction=botaction,
     )
 
@@ -406,7 +416,7 @@ def test_failure_author_not_signed_up(test_db_conn, mock_client):
         text="Unable to hide post: post author is not signed up to the feeds.",
     )
     check_botactions_entry(
-        command=hide_command, 
+        command=hide_command,
         botaction=botaction,
     )
 
@@ -472,7 +482,7 @@ def test_failure_post_not_in_feeds(test_db_conn, mock_client):
         text="Unable to hide post: post is not in feeds.",
     )
     check_botactions_entry(
-        command=hide_command, 
+        command=hide_command,
         botaction=botaction,
     )
 
@@ -535,6 +545,6 @@ def test_failure_post_already_hidden(test_db_conn, mock_client):
         text="Unable to hide post: post already hidden.",
     )
     check_botactions_entry(
-        command=hide_command, 
+        command=hide_command,
         botaction=botaction,
     )

--- a/tests/astrobot/test_command_hide.py
+++ b/tests/astrobot/test_command_hide.py
@@ -1,4 +1,3 @@
-from datetime import datetime, timezone
 from dataclasses import asdict
 
 from astrofeed_lib.database import BotActions, ModActions, Post, Account
@@ -8,14 +7,12 @@ from astrobot.commands.moderation.hide import ModeratorHideCommand
 from astrobot.notifications import MentionNotification
 from astrobot.generate_notification import build_notification, build_reply_ref
 from astrobot.config import HANDLE
-from astrobot.post import get_embed_info, get_reply_info
 from tests.test_lib.test_database import (
     testdb_account_entry,
     testdb_post_entry,
     generate_testdb_post_by_author,
 )
-
-from tests.conftest import MockClient
+from tests.test_lib.test_util import check_call_signature, check_botactions_entry, check_modactions_entry
 
 #
 # utility functions
@@ -39,90 +36,6 @@ def get_hide_command(
         author_did=moderator_account.did,
     )
     return ModeratorHideCommand(MentionNotification(hide_notification))
-
-
-def check_call_signature(
-    hide_command: ModeratorHideCommand,
-    mock_client: MockClient,
-    # currently, the expected post text is all that varies that isn't contained in the hide command itself
-    text: str,
-):
-    """Checks that the the call signature recorded by a MockClient.send_post call reflects data in the executed hide command.
-
-    Most of the details of what we expect to be in this call come from the command object and its
-    associated notification; the expected post text is the only thing that doesn't, so it gets its
-    own argument.
-
-    note: the hide command performs the following call to astrobot.post.send_post()
-    >> send_post(
-    >>     client=client,
-    >>     text=explanation,
-    >>     root_post=self.notification.root_ref,
-    >>     parent_post=self.notification.parent_ref,
-    >> )
-    (additional argument name specifiers added to the first two arguments for clarity),
-    which leaves its other arguments as defaults image=None, image_alt=None, embed=None, quote=None
-
-    Within astrobot.post.send_post, we then have
-    >> reply_info = get_reply_info(root_post, parent_post)
-    >> embed_info = get_embed_info(embed, quote)
-    before finally having the call
-    >> client.send_post(text=text, reply_to=reply_info, embed=embed_info)
-    which leaves its other arguments as defaults profile_identify = None, langs = None, facets = None
-
-    The result of all of this is that only the text and reply_to arguments can possibly have any
-    information that is not specified in the defaults of the astrobot.post.send_post and
-    atproto.Client.send_post funtions; all other information should be the same for each case,
-    and will be determined purely by non-overidden default values from the function definitions.
-    """
-    call_signature = mock_client.send_post_call_signature
-    parent_ref = hide_command.notification.parent_ref
-    root_ref = hide_command.notification.root_ref
-
-    # information specific to each case
-    assert call_signature["text"] == text
-    assert call_signature["reply_to"] == get_reply_info(root_ref, parent_ref)
-
-    # information defined by non-overidden funtion definition default values
-    assert call_signature["profile_identify"] is None
-    assert call_signature["embed"] == get_embed_info(None, None)
-    assert call_signature["langs"] is None
-    assert call_signature["facets"] is None
-
-
-def check_botactions_entry(hide_command: ModeratorHideCommand, botaction: BotActions):
-    """Checks that the BotActions table entry reflects data in the executed hide command."""
-    with DBConnection():
-        mod_level = (
-            Account.select()
-            .where(Account.did == hide_command.notification.author.did)[0]
-            .mod_level
-        )
-
-    assert botaction.indexed_at < datetime.now(timezone.utc).replace(tzinfo=None)
-    assert botaction.did == hide_command.notification.author.did
-    assert botaction.type == hide_command.command
-    assert botaction.stage == "complete"
-    assert botaction.parent_uri == hide_command.notification.parent_ref.uri
-    assert botaction.parent_cid == hide_command.notification.parent_ref.cid
-    assert botaction.latest_uri == hide_command.notification.parent_ref.uri
-    assert botaction.latest_cid == hide_command.notification.parent_ref.cid
-    assert botaction.complete
-    assert botaction.authorized == (mod_level >= hide_command.level)
-    assert botaction.checked_at < datetime.now(timezone.utc).replace(tzinfo=None)
-
-
-def check_modactions_entry(hide_command: ModeratorHideCommand, modaction: ModActions):
-    """Checks that the ModActions table entry reflects data in the executed hide command."""
-    assert modaction.indexed_at < datetime.now(timezone.utc).replace(tzinfo=None)
-    assert modaction.did_mod == hide_command.notification.notification.author.did
-    assert (
-        modaction.did_user
-        == hide_command.notification.notification.record.reply.parent.uri.replace(
-            "at://", ""
-        ).split("/")[0]
-    )
-    assert modaction.expiry is None
 
 
 #
@@ -178,12 +91,19 @@ def test_success(test_db_conn, mock_client):
     assert author_account_after.hidden_count == author_account_before.hidden_count + 1
 
     check_call_signature(
-        hide_command=hide_command,
+        command=hide_command,
         mock_client=mock_client,
         text="Post hidden from feeds successfully.",
     )
-    check_botactions_entry(hide_command, botaction)
-    check_modactions_entry(hide_command, modaction)
+    check_botactions_entry(
+        command=hide_command, 
+        botaction=botaction,
+    )
+    check_modactions_entry(
+        command=hide_command,
+        did_user=hide_command.notification.notification.record.reply.parent.uri.replace("at://", "").split("/")[0],
+        modaction=modaction,
+    )
 
 
 def test_success_multiple_author_entries(test_db_conn, mock_client):
@@ -257,12 +177,19 @@ def test_success_multiple_author_entries(test_db_conn, mock_client):
     assert target_post_after.hidden
 
     check_call_signature(
-        hide_command=hide_command,
+        command=hide_command,
         mock_client=mock_client,
         text="Post hidden from feeds successfully.",
     )
-    check_botactions_entry(hide_command, botaction)
-    check_modactions_entry(hide_command, modaction)
+    check_botactions_entry(
+        command=hide_command, 
+        botaction=botaction,
+    )
+    check_modactions_entry(
+        command=hide_command,
+        did_user=hide_command.notification.notification.record.reply.parent.uri.replace("at://", "").split("/")[0],
+        modaction=modaction,
+    )
 
 
 def test_success_multiple_post_entries(test_db_conn, mock_client):
@@ -337,12 +264,19 @@ def test_success_multiple_post_entries(test_db_conn, mock_client):
     assert author_account_after.hidden_count == author_account_before.hidden_count + 1
 
     check_call_signature(
-        hide_command=hide_command,
+        command=hide_command,
         mock_client=mock_client,
         text="Post hidden from feeds successfully.",
     )
-    check_botactions_entry(hide_command, botaction)
-    check_modactions_entry(hide_command, modaction)
+    check_botactions_entry(
+        command=hide_command, 
+        botaction=botaction,
+    )
+    check_modactions_entry(
+        command=hide_command,
+        did_user=hide_command.notification.notification.record.reply.parent.uri.replace("at://", "").split("/")[0],
+        modaction=modaction,
+    )
 
 
 def test_failure_insufficient_mod_level(test_db_conn, mock_client):
@@ -398,11 +332,14 @@ def test_failure_insufficient_mod_level(test_db_conn, mock_client):
     assert n_modactions == 0
 
     check_call_signature(
-        hide_command=hide_command,
+        command=hide_command,
         mock_client=mock_client,
         text="Sorry, but you don't have the required permissions to run this command. Reason: Lacking required moderator level (2)",
     )
-    check_botactions_entry(hide_command, botaction)
+    check_botactions_entry(
+        command=hide_command, 
+        botaction=botaction,
+    )
 
 
 def test_failure_author_not_signed_up(test_db_conn, mock_client):
@@ -464,11 +401,14 @@ def test_failure_author_not_signed_up(test_db_conn, mock_client):
     assert n_modactions == 0
 
     check_call_signature(
-        hide_command=hide_command,
+        command=hide_command,
         mock_client=mock_client,
         text="Unable to hide post: post author is not signed up to the feeds.",
     )
-    check_botactions_entry(hide_command, botaction)
+    check_botactions_entry(
+        command=hide_command, 
+        botaction=botaction,
+    )
 
 
 def test_failure_post_not_in_feeds(test_db_conn, mock_client):
@@ -527,11 +467,14 @@ def test_failure_post_not_in_feeds(test_db_conn, mock_client):
     assert n_modactions == 0
 
     check_call_signature(
-        hide_command=hide_command,
+        command=hide_command,
         mock_client=mock_client,
         text="Unable to hide post: post is not in feeds.",
     )
-    check_botactions_entry(hide_command, botaction)
+    check_botactions_entry(
+        command=hide_command, 
+        botaction=botaction,
+    )
 
 
 def test_failure_post_already_hidden(test_db_conn, mock_client):
@@ -587,8 +530,11 @@ def test_failure_post_already_hidden(test_db_conn, mock_client):
     assert n_modactions == 0
 
     check_call_signature(
-        hide_command=hide_command,
+        command=hide_command,
         mock_client=mock_client,
         text="Unable to hide post: post already hidden.",
     )
-    check_botactions_entry(hide_command, botaction)
+    check_botactions_entry(
+        command=hide_command, 
+        botaction=botaction,
+    )

--- a/tests/astrobot/test_command_joke.py
+++ b/tests/astrobot/test_command_joke.py
@@ -1,51 +1,60 @@
-from datetime import datetime, timezone
-from atproto import models
-
-from astrofeed_lib.database import BotActions
+from astrofeed_lib.database import BotActions, Account
 from astrofeed_lib.database import DBConnection
 
 from astrobot.commands.joke import JokeCommand, jokes
 from astrobot.notifications import MentionNotification
-from astrobot.generate_notification import build_notification, build_reply_ref
+from astrobot.generate_notification import build_notification
 from astrobot.config import HANDLE
 
+from tests.test_lib.test_database import testdb_account_entry
+from tests.test_lib.test_util import check_call_signature, check_botactions_entry
+
+#
+# utility functions
+#
+
+# cannot be a fixture, unfortunately, since each test needs to specify target post and author differently
+def get_joke_command(
+    requesting_user: Account | testdb_account_entry,
+):
+    """Builds a hide command object given a target post and moderator account."""
+    # we don't store root uri and cid in our Post table, leaving those as default values
+    joke_notification = build_notification(
+        "mention", 
+        record_text=f"@{HANDLE} joke", 
+        author_did=requesting_user.did
+    )
+    return JokeCommand(MentionNotification(joke_notification))
+
+
+#
+# test functions
+#
 
 def test_joke(test_db_conn, mock_client):
-    # create a joke command object with a mock notification
-    joke_notification = build_notification(
-        "mention", record_text=f"@{HANDLE} joke", author_did="test_joke_unit"
-    )
-    joke_command = JokeCommand(MentionNotification(joke_notification))
+    # connect & collect
+    with DBConnection():
+        requesting_account = Account.select()[0]
+
+    # get our joke command
+    joke_command = get_joke_command(requesting_user=requesting_account)
 
     # act
     joke_command.execute(mock_client)
 
-    # extract quantities of interest and make assertions
-    send_post_call_signature = mock_client.send_post_call_signature
-    joke_strong_ref = models.create_strong_ref(joke_notification)
-    joke_reply_ref = build_reply_ref(
-        parent_ref_cid=joke_strong_ref.cid,
-        parent_ref_uri=joke_strong_ref.uri,
-        root_ref_cid=joke_strong_ref.cid,
-        root_ref_uri=joke_strong_ref.uri,
-    )
-    assert send_post_call_signature["text"] in jokes
-    assert send_post_call_signature["profile_identify"] is None
-    assert send_post_call_signature["reply_to"] == joke_reply_ref
-    assert send_post_call_signature["embed"] is None
-    assert send_post_call_signature["langs"] is None
-    assert send_post_call_signature["facets"] is None
-
+    # post-act connect & collect
     with DBConnection():
-        test_entry = BotActions.select().where(BotActions.did == "test_joke_unit")[0]
-    assert test_entry.indexed_at < datetime.now(timezone.utc).replace(tzinfo=None)  # better datetime test?
-    assert test_entry.did == joke_notification.author.did
-    assert test_entry.type == joke_command.command
-    assert test_entry.stage == "complete"
-    assert test_entry.parent_uri == joke_notification.uri
-    assert test_entry.parent_cid == joke_notification.cid
-    assert test_entry.latest_uri == joke_notification.uri
-    assert test_entry.latest_cid == joke_notification.cid
-    assert test_entry.complete
-    assert test_entry.authorized
-    assert test_entry.checked_at < datetime.now(timezone.utc).replace(tzinfo=None)  # ditto above
+        botaction = BotActions.select().where(
+            BotActions.parent_uri == joke_command.notification.parent_ref.uri
+        )[0]
+
+    # checks
+    check_call_signature(
+        command=joke_command,
+        mock_client=mock_client,
+        text=jokes,
+    )
+    check_botactions_entry(
+        command=joke_command, 
+        botaction=botaction,
+    )

--- a/tests/astrobot/test_command_joke.py
+++ b/tests/astrobot/test_command_joke.py
@@ -13,6 +13,7 @@ from tests.test_lib.test_util import check_call_signature, check_botactions_entr
 # utility functions
 #
 
+
 # cannot be a fixture, unfortunately, since each test needs to specify target post and author differently
 def get_joke_command(
     requesting_user: Account | testdb_account_entry,
@@ -20,9 +21,7 @@ def get_joke_command(
     """Builds a hide command object given a target post and moderator account."""
     # we don't store root uri and cid in our Post table, leaving those as default values
     joke_notification = build_notification(
-        "mention", 
-        record_text=f"@{HANDLE} joke", 
-        author_did=requesting_user.did
+        "mention", record_text=f"@{HANDLE} joke", author_did=requesting_user.did
     )
     return JokeCommand(MentionNotification(joke_notification))
 
@@ -30,6 +29,7 @@ def get_joke_command(
 #
 # test functions
 #
+
 
 def test_joke(test_db_conn, mock_client):
     # connect & collect
@@ -55,6 +55,6 @@ def test_joke(test_db_conn, mock_client):
         text=jokes,
     )
     check_botactions_entry(
-        command=joke_command, 
+        command=joke_command,
         botaction=botaction,
     )

--- a/tests/test_lib/test_util.py
+++ b/tests/test_lib/test_util.py
@@ -8,6 +8,7 @@ from astrofeed_lib.database import DBConnection
 
 from tests.conftest import MockClient
 
+
 def check_call_signature(
     command: Command,
     mock_client: MockClient,
@@ -47,7 +48,9 @@ def check_call_signature(
     root_ref = command.notification.root_ref
 
     # information specific to each case
-    if type(text) is str: # hack to allow for testing multiple possibilities at once (mostly for joke command)
+    if (
+        type(text) is str
+    ):  # hack to allow for testing multiple possibilities at once (mostly for joke command)
         text = [text]
     assert call_signature["text"] in text
     assert call_signature["reply_to"] == get_reply_info(root_ref, parent_ref)
@@ -81,7 +84,7 @@ def check_botactions_entry(command: Command, botaction: BotActions):
     assert botaction.checked_at < datetime.now(timezone.utc).replace(tzinfo=None)
 
 
-def check_modactions_entry(command: Command, did_user : str, modaction: ModActions):
+def check_modactions_entry(command: Command, did_user: str, modaction: ModActions):
     """Checks that the ModActions table entry reflects data in an executed command."""
     assert modaction.indexed_at < datetime.now(timezone.utc).replace(tzinfo=None)
     assert modaction.did_mod == command.notification.notification.author.did

--- a/tests/test_lib/test_util.py
+++ b/tests/test_lib/test_util.py
@@ -1,0 +1,89 @@
+from datetime import datetime, timezone
+
+from astrobot.commands._base import Command
+from astrobot.post import get_embed_info, get_reply_info
+
+from astrofeed_lib.database import BotActions, ModActions, Account
+from astrofeed_lib.database import DBConnection
+
+from tests.conftest import MockClient
+
+def check_call_signature(
+    command: Command,
+    mock_client: MockClient,
+    # currently, the expected post text is all that varies that isn't contained in the command itself
+    text: str | list[str],
+):
+    """Checks that the the call signature recorded by a MockClient.send_post call reflects data in an executed command.
+
+    Most of the details of what we expect to be in this call come from the command object and its
+    associated notification; the expected post text is the only thing that doesn't, so it gets its
+    own argument.
+
+    note: commands typically perform the following call to astrobot.post.send_post()
+    >> send_post(
+    >>     client=client,
+    >>     text=explanation,
+    >>     root_post=self.notification.root_ref,
+    >>     parent_post=self.notification.parent_ref,
+    >> )
+    (additional argument name specifiers added to the first two arguments for clarity),
+    which leaves its other arguments as defaults image=None, image_alt=None, embed=None, quote=None
+
+    Within astrobot.post.send_post, we then have
+    >> reply_info = get_reply_info(root_post, parent_post)
+    >> embed_info = get_embed_info(embed, quote)
+    before finally having the call
+    >> client.send_post(text=text, reply_to=reply_info, embed=embed_info)
+    which leaves its other arguments as defaults profile_identify = None, langs = None, facets = None
+
+    The result of all of this is that only the text and reply_to arguments can possibly have any
+    information that is not specified in the defaults of the astrobot.post.send_post and
+    atproto.Client.send_post funtions; all other information should be the same for each case,
+    and will be determined purely by non-overidden default values from the function definitions.
+    """
+    call_signature = mock_client.send_post_call_signature
+    parent_ref = command.notification.parent_ref
+    root_ref = command.notification.root_ref
+
+    # information specific to each case
+    if type(text) is str: # hack to allow for testing multiple possibilities at once (mostly for joke command)
+        text = [text]
+    assert call_signature["text"] in text
+    assert call_signature["reply_to"] == get_reply_info(root_ref, parent_ref)
+
+    # information defined by non-overidden funtion definition default values
+    assert call_signature["profile_identify"] is None
+    assert call_signature["embed"] == get_embed_info(None, None)
+    assert call_signature["langs"] is None
+    assert call_signature["facets"] is None
+
+
+def check_botactions_entry(command: Command, botaction: BotActions):
+    """Checks that the BotActions table entry reflects data in an executed command."""
+    with DBConnection():
+        mod_level = (
+            Account.select()
+            .where(Account.did == command.notification.author.did)[0]
+            .mod_level
+        )
+
+    assert botaction.indexed_at < datetime.now(timezone.utc).replace(tzinfo=None)
+    assert botaction.did == command.notification.author.did
+    assert botaction.type == command.command
+    assert botaction.stage == "complete"
+    assert botaction.parent_uri == command.notification.parent_ref.uri
+    assert botaction.parent_cid == command.notification.parent_ref.cid
+    assert botaction.latest_uri == command.notification.parent_ref.uri
+    assert botaction.latest_cid == command.notification.parent_ref.cid
+    assert botaction.complete
+    assert botaction.authorized == (mod_level >= command.level)
+    assert botaction.checked_at < datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def check_modactions_entry(command: Command, did_user : str, modaction: ModActions):
+    """Checks that the ModActions table entry reflects data in an executed command."""
+    assert modaction.indexed_at < datetime.now(timezone.utc).replace(tzinfo=None)
+    assert modaction.did_mod == command.notification.notification.author.did
+    assert modaction.did_user == did_user
+    assert modaction.expiry is None


### PR DESCRIPTION
This branch makes modifications required to implement and test a moderator command to ban a specified user from the feeds, and makes some additional related changes to the testing structure for other commands.

To implement the ban command, `astrobot.database` has been modified, to add a `ban_user_by_did` function, which takes a DID string as an argument, checks to make sure it corresponds to an entry in our Account table and executes the ban if so, and returns a boolean the indicate success or failure, and a string explaining what happened; `astrobot.moderation` has been modified to implement the previously unimplemented `ban_user` function, which takes a user and moderator DID, and then uses the `astrobot.database.ban_user_by_did` function to attempt the ban, noting the result in the logger and creating a new ModActions entry if the ban was successful, and returning the given explanation for what happened; and finally,  `astrobot.commands.moderation.ban` has been modified to implement the `ModeratorBanCommand.__init__` and `ModeratorBanCommand.execute_good_permissions` methods, which allows this class to be instantiated, and to process the command's triggering notification to extract the handle of the user to ban and the given reason for the ban, attempt to resolve the handle to a did, use the `astrobot.moderation.ban_user` function to attempt the ban and get an explanation of what happened, send a post to the instigating moderator to explain what was done, and create a new corresponding BotActions entry.

To implement the associated tests, the file `test_command_ban.py` was added to `tests/astrobot/` to define the test functions for various test cases, and a `conftest.py` file was added to the `tests/astrobot/` directory to define a mock IDResolver class and provide a fixture to swap it into the ban command module in place of the actual one, in order to succeed or fail to resolve a given handle to a DID without a network-connected API call, to allow for offline and easily repeatable and controllable testing. This was put into an `astrobot` specific file (rather than in the `tests/conftest.py` file which defines things that are visible to all tests) because for now it is only useful to the astrobot tests.

Finally, because several of the "checking" methods (to check that BotActions, ModActions, and the `send_post` call signature) are useful to all of the tests, I have moved their definitions out of `test_command_hide` and into a separate module at `tests.test_lib.test_util`, so that all tests can easily access them; and have reworked both `test_command_joke` and `test_command_hide` to use these shared resources.