### PR TITLE
Hotfix: prevent banned accounts interacting with bot

### DIFF
--- a/src/astrobot/moderation.py
+++ b/src/astrobot/moderation.py
@@ -1,6 +1,6 @@
 """Moderation-related actions."""
 
-from astrofeed_lib.accounts import CachedModeratorList
+from astrofeed_lib.accounts import CachedModeratorList, CachedBannedList
 from astrobot.database import (
     new_mod_action,
     new_signup,
@@ -12,6 +12,7 @@ from astrofeed_lib import logger
 
 # Setup list of moderators
 MODERATORS = CachedModeratorList(query_interval=60)
+BANNED_USERS = CachedBannedList(query_interval=60)
 
 
 def ban_user(did: str, did_mod: str, reason: str):

--- a/src/astrofeed_lib/accounts.py
+++ b/src/astrofeed_lib/accounts.py
@@ -79,7 +79,17 @@ class CachedModeratorList(CachedAccountQuery):
         }
 
 
+class CachedBannedList(CachedAccountQuery):
+    def account_query(self):
+        return get_banned_accounts()
+
+
 def get_moderators() -> dict[str, int]:
     """Returns a set containing the DIDs of all current moderators."""
     query = Account.select(Account.did, Account.mod_level).where(Account.mod_level >= 1)  # type: ignore
     return {user.did: user.mod_level for user in query.execute()}
+
+
+def get_banned_accounts() -> set[str]:
+    query = Account.select(Account.did).where(Account.is_banned)
+    return {user.did for user in query.execute()}

--- a/src/astrofeed_lib/accounts.py
+++ b/src/astrofeed_lib/accounts.py
@@ -63,13 +63,6 @@ class CachedModeratorList(CachedAccountQuery):
     def account_query(self):
         return get_moderators()
 
-    def get_accounts(self) -> dict:
-        is_overdue = time.time() - self.last_query_time > self.query_interval
-        if is_overdue or self.accounts is None:
-            self.query_database()
-            self.last_query_time = time.time()
-        return self.accounts  # type: ignore
-
     def get_accounts_above_level(self, minimum_level: int) -> set[str]:
         """Wraps get_accounts and returns only moderators with the desired minimum
         level.


### PR DESCRIPTION
This hotfix should prevent banned accounts from interacting with any bot commands by adding a check in the base command of the bot. 

I don't have the new test infra set up and we should get into the habit of not having all my code go unreviewed - @vincentscarpenter could you do a review?

We may want to add a test case here, but it isn't essential right now IMO - we could add test cases in another PR, as I think getting this fix out soon would be good.