### PR TITLE
hotfix: deprecated utcnow calls

### DIFF
--- a/src/astrofeed_lib/database.py
+++ b/src/astrofeed_lib/database.py
@@ -189,10 +189,10 @@ class DBConnection(object):
 
 def datetime_now_utc_naive():
     """Provides a timezone-unaware datetime object, making use only of non-deprecated datetime functions.
-    
-    Given that we have timezone-unaware columns in our database, we need to be able to give a function that 
-    supplies up-to-date at time-of-call, UTC-aligned timezone unaware datetime objects to the peewee DateTimeField 
-    constructor's default argument. For now, this seems like the best way to do that withough incurring ~1 million 
+
+    Given that we have timezone-unaware columns in our database, we need to be able to give a function that
+    supplies up-to-date at time-of-call, UTC-aligned timezone unaware datetime objects to the peewee DateTimeField
+    constructor's default argument. For now, this seems like the best way to do that withough incurring ~1 million
     deprecation warnings in everything.
     """
     return datetime.now(timezone.utc).replace(tzinfo=None)
@@ -204,7 +204,9 @@ class BaseModel(peewee.Model):
 
 
 class Post(BaseModel):
-    indexed_at = peewee.DateTimeField(default=datetime_now_utc_naive, index=True)  # Todo: find a non-deprecated alternative method (must be a method peewee can call!)
+    indexed_at = peewee.DateTimeField(
+        default=datetime_now_utc_naive, index=True
+    )  # Todo: find a non-deprecated alternative method (must be a method peewee can call!)
     uri = peewee.CharField(index=True)
     cid = peewee.CharField(index=True)
     author = peewee.CharField(index=True)
@@ -291,7 +293,9 @@ class BotActions(BaseModel):
     latest_cid = peewee.CharField(null=False, default="")
     complete = peewee.BooleanField(null=False, default=False, index=True)
     authorized = peewee.BooleanField(null=False, index=True, default=True)
-    checked_at = peewee.DateTimeField(null=False, index=True, default=datetime_now_utc_naive)
+    checked_at = peewee.DateTimeField(
+        null=False, index=True, default=datetime_now_utc_naive
+    )
 
 
 class ModActions(BaseModel):

--- a/src/astrofeed_lib/database.py
+++ b/src/astrofeed_lib/database.py
@@ -187,7 +187,7 @@ class DBConnection(object):
         teardown_connection(proxy)
 
 
-def datetime_now_utc_unaware():
+def datetime_now_utc_naive():
     """Provides a timezone-unaware datetime object, making use only of non-deprecated datetime functions.
     
     Given that we have timezone-unaware columns in our database, we need to be able to give a function that 
@@ -204,7 +204,7 @@ class BaseModel(peewee.Model):
 
 
 class Post(BaseModel):
-    indexed_at = peewee.DateTimeField(default=datetime_now_utc_unaware, index=True)  # Todo: find a non-deprecated alternative method (must be a method peewee can call!)
+    indexed_at = peewee.DateTimeField(default=datetime_now_utc_naive, index=True)  # Todo: find a non-deprecated alternative method (must be a method peewee can call!)
     uri = peewee.CharField(index=True)
     cid = peewee.CharField(index=True)
     author = peewee.CharField(index=True)
@@ -256,7 +256,7 @@ class SubscriptionState(BaseModel):
 class Account(BaseModel):
     handle = peewee.CharField(index=True)
     did = peewee.CharField(default="not set", index=True)
-    indexed_at = peewee.DateTimeField(default=datetime_now_utc_unaware, index=True)
+    indexed_at = peewee.DateTimeField(default=datetime_now_utc_naive, index=True)
 
     # Account flags
     is_valid = peewee.BooleanField(index=True)
@@ -279,7 +279,7 @@ class Account(BaseModel):
 
 
 class BotActions(BaseModel):
-    indexed_at = peewee.DateTimeField(default=datetime_now_utc_unaware, index=True)
+    indexed_at = peewee.DateTimeField(default=datetime_now_utc_naive, index=True)
     did = peewee.CharField(default="not set")
     type = peewee.CharField(null=False, default="unrecognized", index=True)
     stage = peewee.CharField(
@@ -291,11 +291,11 @@ class BotActions(BaseModel):
     latest_cid = peewee.CharField(null=False, default="")
     complete = peewee.BooleanField(null=False, default=False, index=True)
     authorized = peewee.BooleanField(null=False, index=True, default=True)
-    checked_at = peewee.DateTimeField(null=False, index=True, default=datetime_now_utc_unaware)
+    checked_at = peewee.DateTimeField(null=False, index=True, default=datetime_now_utc_naive)
 
 
 class ModActions(BaseModel):
-    indexed_at = peewee.DateTimeField(default=datetime_now_utc_unaware, index=True)
+    indexed_at = peewee.DateTimeField(default=datetime_now_utc_naive, index=True)
     did_mod = peewee.CharField(index=True, null=False)
     did_user = peewee.CharField(index=True, null=True)
     action = peewee.CharField(index=True, null=False)
@@ -303,7 +303,7 @@ class ModActions(BaseModel):
 
 
 class ActivityLog(BaseModel):
-    request_dt = peewee.DateTimeField(default=datetime_now_utc_unaware, index=True)
+    request_dt = peewee.DateTimeField(default=datetime_now_utc_naive, index=True)
     request_feed_uri = peewee.CharField(index=True, null=False)
     request_limit = peewee.IntegerField(index=False, null=False, default=0)
     request_is_scrolled = peewee.BooleanField(null=False, default=False)


### PR DESCRIPTION
While working on the test database infrastructure PostgreSQL migration, I again encountered the deprecation warnings from the use of `datetime.utcnow` for the default values of the `peewee.DateTimeField`s...and decided to try to fix this!

It ended up being a _little_ tricky --- since we have timezone-naive columns in the database, we need to supply timezone-naive datetime objects as values for these fields to peewee; and since we want the default values to be the current time/date _at whatever time in the future a new database entry is created_, we have to set the default value for these fields to a function, which when called in the future will provide an up-to-date datetime object; rather than setting it to a datetime object which is instantiated (and therefore has it's recorded date/time frozen) at the time of calling the DateTimeField constructor method, which will happen whenever the model class definition code is executed.

The way Python seems to be approaching this makes this set of requirements tricky; they seem to have deprecated _every_ function call that provides a naive object, and the only way to include timezone information seems to be to instantiate an object by actually calling `datetime.now(timezone.whatever)`, such that a tzinfo object can be attached to it.

So, as far as I can tell, what I've implemented here is the best way to achieve what we need --- there is a new function, `datetime_now_utc_naive`, that simply instantiates a new datetime object at time-of-call, with a UTC aligned time, and then strips the tzinfo off of this object and returns it. As far as I have been able to test it, this does correctly produce a UTC time in the resulting object, which is also naive (due to lack of tzinfo), and this has no effect on the automated tests' passage, and produces no deprecation warnings.