### PR TITLE
adding database spec/schema match tests

### DIFF
--- a/tests/astrofeed_lib/test_database_spec.py
+++ b/tests/astrofeed_lib/test_database_spec.py
@@ -1,0 +1,137 @@
+from sys import modules
+from inspect import getmembers, isfunction, isclass
+
+from peewee import IntegerField, BigIntegerField, CharField, BooleanField, DateTimeField
+
+import astrofeed_lib.database # importing as a whole module to search with dir
+from astrofeed_lib.database import proxy, BaseModel, DBConnection
+from astrofeed_lib.database import Account, Post, BotActions, ModActions, SubscriptionState, ActivityLog
+
+model_names = []
+for model_name in dir(astrofeed_lib.database):
+    model = getattr(astrofeed_lib.database, model_name)
+    if (isclass(model) and issubclass(model, BaseModel) and model != BaseModel):
+        model_names.append(model.__name__.lower())
+
+with DBConnection():
+    table_names = proxy.get_tables()
+
+postgres_type_label_to_peewee_field_type = {
+    "integer": IntegerField,
+    "bigint": BigIntegerField,
+    "character varying": CharField,
+    "boolean": BooleanField,
+    "timestamp without time zone": DateTimeField,
+}
+
+#
+# utility functions
+#
+def get_database_table_info(table_name: str):
+    """Fetch and return certain column info from specified table in astrofeed_lib.database.proxy database (postgres presumed)."""
+    with DBConnection():
+        cursor = proxy.execute_sql("SELECT column_name, data_type, character_maximum_length, is_nullable, column_default "
+                                   "FROM information_schema.columns "
+                                   f"WHERE table_name = '{table_name}' AND table_schema = 'public';")
+
+    names, typelabels, maxlengths, nullables, has_defaults  = [], [], [], [], []
+    for row in cursor.fetchall():
+        column_name, data_type, max_length, is_nullable, default_value = row
+        if column_name == "id": # don't need this column
+            continue
+        names.append(column_name)
+        typelabels.append(data_type)
+        maxlengths.append(max_length)
+        nullables.append(is_nullable == "YES")
+        has_defaults.append(default_value is not None)
+
+    return names, typelabels, maxlengths, nullables, has_defaults
+
+def check_peewee_spec_compatibility(
+        model: BaseModel,
+        names: list[str], 
+        typelabels: list[str], 
+        maxlengths: list[int],
+        nullables: list[bool], 
+        has_defaults: list[bool], 
+    ):
+    """Assert compatibility of model properties in specified peewee model class with specified table column info."""
+    for name, typelabel, maxlength, nullable, has_default in zip(names, typelabels, maxlengths, nullables, has_defaults):
+        assert hasattr(model, name)
+        column = getattr(model, name)
+        assert type(column) is postgres_type_label_to_peewee_field_type[typelabel]
+        if maxlength is not None:
+            assert column.max_length == maxlength
+        if not has_default and not nullable: # if the column is not nullable and has no default value, cannot be null in peewee
+            assert not column.null
+
+#
+# test functions
+#
+
+def test_peewee_spec_coverage():
+    """Tests that the peewee spec has a model class defined for each table in database."""
+    for table_name in table_names:
+        assert table_name in model_names
+
+
+def test_account():
+    """Tests compatibility between specs for peewee Account model class and database Account table."""
+    # get info about the account table
+    table_info = get_database_table_info("account")
+
+    # check for parity with model class
+    check_peewee_spec_compatibility(Account, *table_info)
+
+
+def test_post():
+    """Tests compatibility between specs for peewee Post model class and database Post table."""
+    # get info about the account table
+    table_info = get_database_table_info("post")
+
+    # check for parity with model class
+    check_peewee_spec_compatibility(Post, *table_info)
+
+
+def test_botactions():
+    """Tests compatibility between specs for peewee BotActions model class and database BotActions table."""
+    # get info about the account table
+    table_info = get_database_table_info("botactions")
+
+    # check for parity with model class
+    check_peewee_spec_compatibility(BotActions, *table_info)
+
+
+def test_modactions():
+    """Tests compatibility between specs for peewee ModActions model class and database ModActions table."""
+    # get info about the account table
+    table_info = get_database_table_info("modactions")
+
+    # check for parity with model class
+    check_peewee_spec_compatibility(ModActions, *table_info)
+
+
+def test_subscriptionstate():
+    """Tests compatibility between specs for peewee SubscriptionState model class and database SubscriptionState table."""
+    # get info about the account table
+    table_info = get_database_table_info("subscriptionstate")
+
+    # check for parity with model class
+    check_peewee_spec_compatibility(SubscriptionState, *table_info)
+
+
+def test_activitylog():
+    """Tests compatibility between specs for peewee ActivityLog model class and database ActivityLog table."""
+    # get info about the account table
+    table_info = get_database_table_info("activitylog")
+
+    # check for parity with model class
+    check_peewee_spec_compatibility(ActivityLog, *table_info)
+
+
+def test_test_case_coverage():
+    """Tests that there is a test case function defined for each model class."""
+    test_case_function_names = [func[0][5:] for func in getmembers(modules[__name__], isfunction) if func[0][:5] == "test_"]
+
+    for table_name in table_names:
+        assert table_name in test_case_function_names

--- a/tests/astrofeed_lib/test_database_spec.py
+++ b/tests/astrofeed_lib/test_database_spec.py
@@ -68,16 +68,16 @@ def get_database_table_info(table_name: str):
             f"WHERE table_name = '{table_name}' AND table_schema = 'public';"
         )
 
-    names, typelabels, maxlengths, nullables, has_defaults = [], [], [], [], []
-    for row in cursor.fetchall():
-        column_name, data_type, max_length, is_nullable, default_value = row
-        if column_name == "id":  # don't need this column
-            continue
-        names.append(column_name)
-        typelabels.append(data_type)
-        maxlengths.append(max_length)
-        nullables.append(is_nullable == "YES")
-        has_defaults.append(default_value is not None)
+        names, typelabels, maxlengths, nullables, has_defaults = [], [], [], [], []
+        for row in cursor.fetchall():
+            column_name, data_type, max_length, is_nullable, default_value = row
+            if column_name == "id":  # don't need this column
+                continue
+            names.append(column_name)
+            typelabels.append(data_type)
+            maxlengths.append(max_length)
+            nullables.append(is_nullable == "YES")
+            has_defaults.append(default_value is not None)
 
     return names, typelabels, maxlengths, nullables, has_defaults
 

--- a/tests/astrofeed_lib/test_database_spec.py
+++ b/tests/astrofeed_lib/test_database_spec.py
@@ -1,5 +1,4 @@
-from sys import modules
-from inspect import getmembers, isfunction, isclass
+from inspect import isclass
 from warnings import warn
 
 from peewee import IntegerField, BigIntegerField, CharField, BooleanField, DateTimeField
@@ -57,7 +56,7 @@ def register_test_function_execution(table_name: str):
     if table_name in tables_to_test.keys():
         tables_to_test[table_name] = True
     else:
-        warn(f"warning: {table_name} test function exists, but was not specified in list of tables to test.")
+        warn(f"{table_name} test function exists, but was not specified in list of tables to test.")
 
 def get_database_table_info(table_name: str):
     """Fetch and return certain column info from specified table in astrofeed_lib.database.proxy database (postgres presumed)."""
@@ -192,4 +191,4 @@ def test_test_case_coverage():
     """Warns if there were any intended test case functions was executed defined for each specified table."""
     for table_name, tested in tables_to_test.items():
         if not tested:
-            warn(f"warning: {table_name} is listed as a table that should be tested, but no test function was recorded as executing for it.")
+            warn(f"{table_name} is listed as a table that should be tested, but no test function was recorded as executing for it.")

--- a/tests/astrofeed_lib/test_database_spec.py
+++ b/tests/astrofeed_lib/test_database_spec.py
@@ -130,7 +130,7 @@ def test_activitylog():
 
 
 def test_test_case_coverage():
-    """Tests that there is a test case function defined for each model class."""
+    """Tests that there is a test case function defined for database table."""
     test_case_function_names = [func[0][5:] for func in getmembers(modules[__name__], isfunction) if func[0][:5] == "test_"]
 
     for table_name in table_names:

--- a/tests/astrofeed_lib/test_database_spec.py
+++ b/tests/astrofeed_lib/test_database_spec.py
@@ -3,14 +3,21 @@ from inspect import getmembers, isfunction, isclass
 
 from peewee import IntegerField, BigIntegerField, CharField, BooleanField, DateTimeField
 
-import astrofeed_lib.database # importing as a whole module to search with dir
+import astrofeed_lib.database  # importing as a whole module to search with dir
 from astrofeed_lib.database import proxy, BaseModel, DBConnection
-from astrofeed_lib.database import Account, Post, BotActions, ModActions, SubscriptionState, ActivityLog
+from astrofeed_lib.database import (
+    Account,
+    Post,
+    BotActions,
+    ModActions,
+    SubscriptionState,
+    ActivityLog,
+)
 
 model_names = []
 for model_name in dir(astrofeed_lib.database):
     model = getattr(astrofeed_lib.database, model_name)
-    if (isclass(model) and issubclass(model, BaseModel) and model != BaseModel):
+    if isclass(model) and issubclass(model, BaseModel) and model != BaseModel:
         model_names.append(model.__name__.lower())
 
 with DBConnection():
@@ -24,20 +31,23 @@ postgres_type_label_to_peewee_field_type = {
     "timestamp without time zone": DateTimeField,
 }
 
+
 #
 # utility functions
 #
 def get_database_table_info(table_name: str):
     """Fetch and return certain column info from specified table in astrofeed_lib.database.proxy database (postgres presumed)."""
     with DBConnection():
-        cursor = proxy.execute_sql("SELECT column_name, data_type, character_maximum_length, is_nullable, column_default "
-                                   "FROM information_schema.columns "
-                                   f"WHERE table_name = '{table_name}' AND table_schema = 'public';")
+        cursor = proxy.execute_sql(
+            "SELECT column_name, data_type, character_maximum_length, is_nullable, column_default "
+            "FROM information_schema.columns "
+            f"WHERE table_name = '{table_name}' AND table_schema = 'public';"
+        )
 
-    names, typelabels, maxlengths, nullables, has_defaults  = [], [], [], [], []
+    names, typelabels, maxlengths, nullables, has_defaults = [], [], [], [], []
     for row in cursor.fetchall():
         column_name, data_type, max_length, is_nullable, default_value = row
-        if column_name == "id": # don't need this column
+        if column_name == "id":  # don't need this column
             continue
         names.append(column_name)
         typelabels.append(data_type)
@@ -47,27 +57,34 @@ def get_database_table_info(table_name: str):
 
     return names, typelabels, maxlengths, nullables, has_defaults
 
+
 def check_peewee_spec_compatibility(
-        model: BaseModel,
-        names: list[str], 
-        typelabels: list[str], 
-        maxlengths: list[int],
-        nullables: list[bool], 
-        has_defaults: list[bool], 
-    ):
+    model: BaseModel,
+    names: list[str],
+    typelabels: list[str],
+    maxlengths: list[int],
+    nullables: list[bool],
+    has_defaults: list[bool],
+):
     """Assert compatibility of model properties in specified peewee model class with specified table column info."""
-    for name, typelabel, maxlength, nullable, has_default in zip(names, typelabels, maxlengths, nullables, has_defaults):
+    for name, typelabel, maxlength, nullable, has_default in zip(
+        names, typelabels, maxlengths, nullables, has_defaults
+    ):
         assert hasattr(model, name)
         column = getattr(model, name)
         assert type(column) is postgres_type_label_to_peewee_field_type[typelabel]
         if maxlength is not None:
             assert column.max_length == maxlength
-        if not has_default and not nullable: # if the column is not nullable and has no default value, cannot be null in peewee
+        if (
+            not has_default and not nullable
+        ):  # if the column is not nullable and has no default value, cannot be null in peewee
             assert not column.null
+
 
 #
 # test functions
 #
+
 
 def test_peewee_spec_coverage():
     """Tests that the peewee spec has a model class defined for each table in database."""
@@ -131,7 +148,11 @@ def test_activitylog():
 
 def test_test_case_coverage():
     """Tests that there is a test case function defined for database table."""
-    test_case_function_names = [func[0][5:] for func in getmembers(modules[__name__], isfunction) if func[0][:5] == "test_"]
+    test_case_function_names = [
+        func[0][5:]
+        for func in getmembers(modules[__name__], isfunction)
+        if func[0][:5] == "test_"
+    ]
 
     for table_name in table_names:
         assert table_name in test_case_function_names

--- a/tests/astrofeed_lib/test_database_spec.py
+++ b/tests/astrofeed_lib/test_database_spec.py
@@ -56,7 +56,10 @@ def register_test_function_execution(table_name: str):
     if table_name in tables_to_test.keys():
         tables_to_test[table_name] = True
     else:
-        warn(f"{table_name} test function exists, but was not specified in list of tables to test.")
+        warn(
+            f"{table_name} test function exists, but was not specified in list of tables to test."
+        )
+
 
 def get_database_table_info(table_name: str):
     """Fetch and return certain column info from specified table in astrofeed_lib.database.proxy database (postgres presumed)."""
@@ -191,4 +194,6 @@ def test_test_case_coverage():
     """Warns if there were any intended test case functions was executed defined for each specified table."""
     for table_name, tested in tables_to_test.items():
         if not tested:
-            warn(f"{table_name} is listed as a table that should be tested, but no test function was recorded as executing for it.")
+            warn(
+                f"{table_name} is listed as a table that should be tested, but no test function was recorded as executing for it."
+            )


### PR DESCRIPTION
Adding a test module for `astrofeed_lib.database`, to make sure that the schema specified in the Peewee model classes there are consistent with the schema of the actual database connected to by the `proxy` variable.

There are (currently) 6 fundamental tests &mdash; one for each database table, named `test_account`, `test_post`, etc &mdash; which check that the corresponding Peewee model class is compatible by asserting the following:
* the Peewee model class has a column of the correct type for each column in the database table;
* for any database column with a max length attribute, the corresponding Peewee column has the same max length;
* for any database column which is not nullable, the corresponding Peewee column _either_ has a default value, or is itself not nullable.

Re: the last point, I have set it up this way to make sure that Peewee will never provide a null value to a database column that cannot accept a null value, either because the Peewee column defines its own default, or it requires whatever gives it values to provide a non-null one.

Additionally, there are two higher-level tests:
1. `test_peewee_spec_coverage`, which ensures that there is a peewee model class defined for each database table; and
2. `test_test_case_coverage`, which ensures that there is a test case defined for each database table.

These tests will hopefully make sure that there is adequate warning if the database specification changes, and the test infrastructure is out-of-date in a way that might cause it not to catch potential issues.