### PR TITLE
Feature dev database endpoint

### DIFF
--- a/files/.gitignore
+++ b/files/.gitignore
@@ -1,0 +1,1 @@
+devdb.sql

--- a/files/README.md
+++ b/files/README.md
@@ -1,0 +1,5 @@
+# Downloadable files
+
+Place files in this directory that can be served for download from the Flask server (e.g. datasets or dev utilities.)
+
+Ensure that all files are also in the .gitignore in this directory so that they don't end up on GitHub.

--- a/src/astrofeed_server/app.py
+++ b/src/astrofeed_server/app.py
@@ -261,7 +261,7 @@ def get_feed_log_by_date():
         return "Ensure the Date is in YYYY-MM-DD format", 400
     return jsonify(body)
 
-@app.route("/download/devdb.sql", methods=["GET"])
+@app.route("/api/dev.downloadDevDB", methods=["GET"])
 def download_dev_db():
     # specify wherever the file is kept (relative to application root path)
     download_dir = os.path.join(current_app.root_path, "downloadable_files")

--- a/src/astrofeed_server/app.py
+++ b/src/astrofeed_server/app.py
@@ -259,7 +259,7 @@ def get_feed_log_by_date():
         return "Ensure the Date is in YYYY-MM-DD format", 400
     return jsonify(body)
 
-@app.route("/download/debdb.sql", methods=["GET"])
+@app.route("/download/devdb.sql", methods=["GET"])
 def download_dev_db():
     return send_from_directory(current_app.root_path, "devdb.sql")
 

--- a/src/astrofeed_server/app.py
+++ b/src/astrofeed_server/app.py
@@ -264,7 +264,7 @@ def get_feed_log_by_date():
 @app.route("/api/dev.downloadDevDB", methods=["GET"])
 def download_dev_db():
     # specify wherever the file is kept (relative to application root path)
-    download_dir = os.path.join(current_app.root_path, "downloadable_files")
+    download_dir = os.path.join(current_app.root_path, "../../files")
     file_path = os.path.join(download_dir, "devdb.sql")
     logger.debug(f"looking for file to download at: {file_path}")
     if os.path.isfile(file_path):

--- a/src/astrofeed_server/app.py
+++ b/src/astrofeed_server/app.py
@@ -1,3 +1,5 @@
+import os
+
 import signal
 from threading import Thread, Event
 from typing import Final
@@ -261,7 +263,15 @@ def get_feed_log_by_date():
 
 @app.route("/download/devdb.sql", methods=["GET"])
 def download_dev_db():
-    return send_from_directory(current_app.root_path, "devdb.sql")
+    # specify wherever the file is kept (relative to application root path)
+    download_dir = os.path.join(current_app.root_path, "downloadable_files")
+    file_path = os.path.join(download_dir, "devdb.sql")
+    logger.debug(f"looking for file to download at: {file_path}")
+    if os.path.isfile(file_path):
+        return send_from_directory(download_dir, "devdb.sql")
+    else:
+        logger.warning(f"Could not locate file at {file_path} to send for download.", exc_info=True)
+        return "couldn't find the dev database file sorry :/"
 
 # -----------------------------------
 # LOGGING HANDLERS

--- a/src/astrofeed_server/app.py
+++ b/src/astrofeed_server/app.py
@@ -2,7 +2,7 @@ import signal
 from threading import Thread, Event
 from typing import Final
 
-from flask import Flask, jsonify, request, Response
+from flask import Flask, jsonify, request, Response, send_from_directory, current_app
 
 from astrofeed_lib import config, logger
 from astrofeed_lib.algorithm import (
@@ -259,6 +259,9 @@ def get_feed_log_by_date():
         return "Ensure the Date is in YYYY-MM-DD format", 400
     return jsonify(body)
 
+@app.route("/download/debdb.sql", methods=["GET"])
+def download_dev_db():
+    return send_from_directory(current_app.root_path, "devdb.sql")
 
 # -----------------------------------
 # LOGGING HANDLERS

--- a/src/astrofeed_server/app.py
+++ b/src/astrofeed_server/app.py
@@ -262,7 +262,16 @@ def get_feed_log_by_date():
     return jsonify(body)
 
 @app.route("/api/dev.downloadDevDB", methods=["GET"])
+# http://127.0.0.1:8000/api/dev.downloadDevDB?token=dev_secret
 def download_dev_db():
+    # authenticate
+    if (dev_token := os.getenv("ASTROFEED_DEV_TOKEN", "")) == "":
+        logger.error("Developer database download token is not set, or is empty; aborting download.")
+        return "Missing Token", 400
+    elif (token := request.args.get("token", default=None, type=str)) != dev_token:
+        logger.warning("retrieved token does not match stored token; aborting download.")
+        return "wrong token value, aborting download"
+
     # specify wherever the file is kept (relative to application root path)
     download_dir = os.path.join(current_app.root_path, "../../files")
     file_path = os.path.join(download_dir, "devdb.sql")

--- a/src/astrofeed_server/app.py
+++ b/src/astrofeed_server/app.py
@@ -268,7 +268,7 @@ def download_dev_db():
     if (dev_token := os.getenv("ASTROFEED_DEV_TOKEN", "")) == "":
         logger.error("Developer database download token is not set, or is empty; aborting download.")
         return "Missing Token", 400
-    elif (token := request.args.get("token", default=None, type=str)) != dev_token:
+    elif (request.args.get("token", default=None, type=str)) != dev_token:
         logger.warning("retrieved token does not match stored token; aborting download.")
         return "wrong token value, aborting download"
 


### PR DESCRIPTION
This branch is intended to add an endpoint to the flask server that allows for the download of the regularly updated developer databases.

For the moment, the only thing that has been added is a single `app.route` decorated function in `src/astrofeed_server/app.py` that makes use of the Flask module's `send_from_directory` function (with `current_app`) to access and send a file named "devdb.sql" from the current application's root.

I plan to add more to this of course, like e.g. checking to make sure the file exists; but wanted to provide this for now, just in case anyone has an immediate idea about whether or not this approach will work, wants to test it for themselves, etc.