### PR TITLE
Feature: dev db obfuscation

### DIFF
--- a/scripts/sql/devdb/populate_dev_db.sql
+++ b/scripts/sql/devdb/populate_dev_db.sql
@@ -73,15 +73,12 @@ DECLARE
 	did obfuscation_map.request_user_did%TYPE;
 	obfuscated_did obfuscation_map.obfuscated_user_did%TYPE;
 BEGIN
-	RAISE NOTICE 'Entering obfuscation function.';
-
 	FOR obfuscation_map_row IN
 	SELECT * FROM obfuscation_map
 	ORDER BY 1
 	LOOP
 		did = obfuscation_map_row.request_user_did;
 		obfuscated_did = obfuscation_map_row.obfuscated_user_did;
-		RAISE NOTICE 'replacing user DID % with obfuscated DID %', quote_ident(did), quote_ident(obfuscated_did);
 		UPDATE public.activitylog
 		SET request_user_did = obfuscated_did
 		WHERE request_user_did = did;

--- a/scripts/sql/devdb/populate_dev_db.sql
+++ b/scripts/sql/devdb/populate_dev_db.sql
@@ -34,7 +34,6 @@ INSERT INTO public.subscriptionstate
 SELECT * from prod_public.subscriptionstate;
 
 -- ActivityLog; take all times Emily has viewed the feeds for now...
--- TODO: replace with anonymizing the DID of users viewing the feed
 DELETE FROM public.activitylog;
 INSERT INTO public.activitylog
 SELECT * FROM (
@@ -43,6 +42,14 @@ SELECT * FROM (
     LIMIT 50000
 )
 ORDER BY request_dt ASC;
+-- anonymize the DID of users viewing the feed (request_user_did field) here!
+/*
+the below code works for simple replacement, but we need to maintain the uniqueness 
+of each did.
+*/
+--UPDATE public.activitylog
+--SET request_user_did = 'did:plc:a'
+--WHERE request_user_did LIKE 'did:plc:%';
 
 -- not taking NormalizedFeedStats for now - maybe generate after the fact?
 

--- a/scripts/sql/devdb/populate_dev_db.sql
+++ b/scripts/sql/devdb/populate_dev_db.sql
@@ -42,14 +42,56 @@ SELECT * FROM (
     LIMIT 50000
 )
 ORDER BY request_dt ASC;
--- anonymize the DID of users viewing the feed (request_user_did field) here!
-/*
-the below code works for simple replacement, but we need to maintain the uniqueness 
-of each did.
-*/
---UPDATE public.activitylog
---SET request_user_did = 'did:plc:a'
---WHERE request_user_did LIKE 'did:plc:%';
+
+/* anonymize user DIDs in activity log
+
+start by gathering all unique user DIDs from activity log into a temporary table */
+DROP TABLE IF EXISTS obfuscation_map;
+CREATE TEMPORARY TABLE obfuscation_map ON COMMIT DROP
+AS
+SELECT DISTINCT ON (request_user_did) request_user_did
+FROM public.activitylog
+WHERE request_user_did != 'Unknown';
+
+/* add a column for corresponding obfuscated did */
+ALTER TABLE obfuscation_map
+ADD COLUMN obfuscated_user_did varchar(255) UNIQUE;
+
+/* fill obfuscated DID column by prepending appropriate DID identifiers to random UUIDs */
+UPDATE obfuscation_map
+SET obfuscated_user_did = 'did:plc:' || gen_random_uuid()
+WHERE request_user_did LIKE 'did:plc:%';
+
+UPDATE obfuscation_map
+SET obfuscated_user_did = 'did:web:' || gen_random_uuid()
+WHERE request_user_did LIKE 'did:web:%';
+
+/* overwrite original DIDs in table with obfuscated DIDs (possibly is a way to do this without scripting, but I didn't find it) */
+CREATE OR REPLACE FUNCTION obfuscate() RETURNS integer AS $$
+DECLARE
+	obfuscation_map_row obfuscation_map%ROWTYPE;
+	did obfuscation_map.request_user_did%TYPE;
+	obfuscated_did obfuscation_map.obfuscated_user_did%TYPE;
+BEGIN
+	RAISE NOTICE 'Entering obfuscation function.';
+
+	FOR obfuscation_map_row IN
+	SELECT * FROM obfuscation_map
+	ORDER BY 1
+	LOOP
+		did = obfuscation_map_row.request_user_did;
+		obfuscated_did = obfuscation_map_row.obfuscated_user_did;
+		RAISE NOTICE 'replacing user DID % with obfuscated DID %', quote_ident(did), quote_ident(obfuscated_did);
+		UPDATE public.activitylog
+		SET request_user_did = obfuscated_did
+		WHERE request_user_did = did;
+	END LOOP;
+
+	RETURN 1;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT obfuscate();
 
 -- not taking NormalizedFeedStats for now - maybe generate after the fact?
 

--- a/scripts/sql/devdb/populate_dev_db.sql
+++ b/scripts/sql/devdb/populate_dev_db.sql
@@ -57,7 +57,11 @@ WHERE request_user_did != 'Unknown';
 ALTER TABLE obfuscation_map
 ADD COLUMN obfuscated_user_did varchar(255) UNIQUE;
 
-/* fill obfuscated DID column by prepending appropriate DID identifiers to random UUIDs */
+/* catch all for anything not matched by a specific pattern */
+UPDATE obfuscation_map
+SET obfuscated_user_did = gen_random_uuid();
+
+/* rules for DIDs with particular patterns to preserve through obfuscation */
 UPDATE obfuscation_map
 SET obfuscated_user_did = 'did:plc:' || gen_random_uuid()
 WHERE request_user_did LIKE 'did:plc:%';


### PR DESCRIPTION
This branch contains changes to the file `scripts/sql/devdb/populate_dev_db.sql`, which is used to move data from the production database to a developer database, that cause it to obfuscate the user DIDs in the `activitylog` table, such that they no longer identify individual users.

This is done by replacing the actual, uniquely identifying DIDs present in the `request_user_did` field of that table in the production database with strings constructed using the `gen_random_uuid` SQL function, in the following way:
1. `activitylog` entries having the value "Unknown" in the `request_user_did` field in the production database will pass that value to the developer database unmodified;
2. all other entries will be assigned a UUID string to be put in the developer database, regardless of their form;
3. any entries with recognized patterns that we would like to preserve (for the moment, this includes entries with values of the form "did:plc:[...]" and "did:web:[...]") will be assigned an updated value for the developer database that keeps the elements of their formatting that we wish to preserve through the obfuscation, while replacing other uniquely identifying elements with randomly generated UUIDs

This assignment is consistent for each input DID within a single application of the obfuscation process, so multiple occurrences of the same user DID in the production database table will all be assigned the same non-identifying obfuscated DID in the developer database; however, note that the assignment method is NOT deterministic based on the input, so the same user DID will NOT be mapped to the same obfuscated DID across separate applications of the obfuscation process.

For illustrative purposes, here are some (hopefully comprehensive) examples of DID replacements that were performed by this process during my testing (with uniquely identifying values changed by hand even for the production entries in this case, of course), across two separate instances of generating a developer database:

| production database DID | developer database 1 DID | developer database 2 DID |
| ------------------------------------- |-------------------------------------- | -------------------------------------- |
|    did:plc:dmugb46u6NoTaReAlDiD4anf   |   did:plc:bc74d528-930d-444e-9d5f-1e71ce198632   | did:plc:e38b2ff2-4655-4e58-a277-44f99fbf18c3 | 
|    did:web:hiiIIIiii                                            |  did:web:eda52602-59a4-43f5-9b4f-59349553a03d | did:web:9b8cbab7-6903-404a-abe3-a644b59c526a |
|    eeehehehe>:D                                            |  db195cb3-0830-425d-b8a9-88b7734e02c4                | fb908750-eb67-4dcb-8fb9-dfa5aa01e793 |
|    Unknown                                                     |  Unknown                                                                          | Unknown |